### PR TITLE
fix(ci): update deploy workflow for Node.js 24 and wrangler 4

### DIFF
--- a/.github/workflows/deploy-worker.yaml
+++ b/.github/workflows/deploy-worker.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v6
       - uses: cloudflare/wrangler-action@v3
@@ -17,3 +19,4 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ac7ee4615628005dc5ba0a22f0aae2a6
           workingDirectory: ${{ inputs.working-directory }}
+          wranglerVersion: "4"


### PR DESCRIPTION
## Summary
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env var to resolve Node.js 20 deprecation warning from `cloudflare/wrangler-action@v3`
- Pin `wranglerVersion: "4"` to resolve outdated wrangler version warning
- Both fixes apply to the shared `deploy-worker.yaml` reusable workflow, covering all three worker deploys (contact_us, feed, auth)

## Test plan
- [ ] Verify deploy workflows run without Node.js 20 deprecation warning
- [ ] Verify wrangler 4 is used and no outdated version warning appears
- [ ] Confirm all three workers deploy successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>