### PR TITLE
feat: add article mustache template for CF overlay demo

### DIFF
--- a/cf-templates/article.html
+++ b/cf-templates/article.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{properties.elements.title.value}}</title>
+    <meta name="template" content="article">
+    <meta name="author" content="{{properties.elements.author.value}}">
+    <meta name="date" content="{{properties.elements.publicationDate.value}}">
+    <meta name="description" content="{{properties.elements.summary.value}}">
+    <meta name="image" content="{{{properties.elements.image.value}}}">
+  </head>
+  <body>
+    <header></header>
+    <main>
+      <div>
+        <div class="hero">
+          <div>
+            <div>
+              <picture>
+                <img src="{{{properties.elements.image.value}}}" alt="{{properties.elements.title.value}}">
+              </picture>
+            </div>
+          </div>
+          <div>
+            <div>
+              <h1>{{properties.elements.title.value}}</h1>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div>
+        <p>{{{properties.elements.summary.value}}}</p>
+      </div>
+    </main>
+    <footer></footer>
+  </body>
+</html>


### PR DESCRIPTION
Adds `cf-templates/article.html` for use with the `json2html` overlay service. Maps CF fields (`title`, `author` etc) to EDS semantic HTML with hero block structure and article template metadata, enabling Article CFs to be published as standalone EDS pages.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--demo--scdemos.aem.live/
- After: https://feat-cf-overlay-article-template--demo--scdemos.aem.live/
