### PR TITLE
feat(cards): add image support to cards links variant

### DIFF
--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -10,7 +10,14 @@ import {
 
 function buildLinksCard(article) {
   const href = normalizePath(article.path);
+  const li = createTag('li');
   const link = createTag('a', { href, class: 'cards-card-link' });
+
+  if (article.image) {
+    const imageDiv = createTag('div', { class: 'cards-card-image' });
+    imageDiv.append(createOptimizedPicture(article.image, article.title || '', false, [{ width: '750' }]));
+    link.append(imageDiv);
+  }
 
   const body = createTag('div', { class: 'cards-card-body' });
   body.append(createTag('p', {}, createTag('strong', {}, article.title || href)));
@@ -18,8 +25,9 @@ function buildLinksCard(article) {
     body.append(createTag('p', {}, article.description));
   }
   link.append(body);
+  li.append(link);
 
-  return createTag('li', {}, link);
+  return li;
 }
 
 /**

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -200,6 +200,7 @@ export function resolveArticlesFromIndex(authoredLinks, indexRows) {
       path: norm,
       title: row?.title?.trim() || linkTitle || fallbackTitle,
       description: row?.description?.trim() || '',
+      image: row?.image?.trim() || '',
       date: row?.date || row?.publisheddate || row?.lastModified,
     };
   });


### PR DESCRIPTION
- `resolveArticlesFromIndex` in `shared.js` now includes the `image` field from the query index
- `cards links` variant renders an optimized `<picture>` when an image is available, matching the default cards layout (image + body)
- Enables the `/articles` landing page (used for demo of Content Fragment Overlay feature) to be authored with just a list of paths — title, description, and hero image resolved dynamically from `query-index.json`

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--demo--scdemos.aem.live/
- After: https://<branch>--demo--scdemos.aem.live/
