### PR TITLE
fix: ignore default meta image for article cards

### DIFF
--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -196,11 +196,13 @@ export function resolveArticlesFromIndex(authoredLinks, indexRows) {
     const norm = normalizePath(path);
     const row = indexRows.find((r) => r?.path && normalizePath(r.path) === norm);
     const fallbackTitle = norm.split('/').filter(Boolean).pop()?.replace(/-/g, ' ') || norm;
+    const img = row?.image?.trim() || '';
+
     return {
       path: norm,
       title: row?.title?.trim() || linkTitle || fallbackTitle,
       description: row?.description?.trim() || '',
-      image: row?.image?.trim() || '',
+      image: img.includes('default-meta-image.png') ? '' : img,
       date: row?.date || row?.publisheddate || row?.lastModified,
     };
   });


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--demo--scdemos.aem.live/
- After: https://fix-card-images--demo--scdemos.aem.live/
