### PR TITLE
feat(article): editorial byline and breadcrumb styling

### DIFF
--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -113,8 +113,8 @@ main hr {
 main > .section:not(.hero-container, .gradient, .ink, .rust) h2::after {
   content: '';
   display: block;
-  width: 2.5rem;
-  height: 2px;
+  width: 3rem;
+  height: 3px;
   margin-top: 0.35em;
   background: var(--gradient-brand);
   border-radius: 1px;

--- a/templates/article/article.css
+++ b/templates/article/article.css
@@ -1,50 +1,96 @@
+/* ==========================================================================
+   Author / Date byline
+   ========================================================================== */
+
 .article .hero .article-author-container {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: space-between;
-  gap: var(--space-s);
+  justify-content: flex-start;
+  gap: 0 var(--space-m);
   max-width: var(--grid-container-width);
   margin: 0 auto;
   width: 100%;
-  font-size: var(--body-font-size-s);
+  padding-top: var(--space-m);
+  border-top: 1px solid light-dark(rgb(161 79 43 / 20%), rgb(245 242 237 / 18%));
+}
+
+.article .hero .article-author {
+  font-size: var(--body-font-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: light-dark(var(--color-rust), var(--color-rust-bright));
+}
+
+.article .hero .article-author::after {
+  content: '·';
+  margin-left: var(--space-m);
+  font-style: normal;
+  color: light-dark(rgb(0 0 0 / 30%), rgb(245 242 237 / 35%));
 }
 
 .article .hero .article-date {
+  font-family: var(--font-family-serif);
+  font-size: var(--body-font-size-s);
+  font-style: italic;
+  color: light-dark(var(--color-gray-600), var(--color-muted));
   white-space: nowrap;
 }
 
+/* ==========================================================================
+   Breadcrumb strip
+   ========================================================================== */
+
 .article .article-breadcrumb {
-  max-width: var(--grid-container-width);
-  margin: var(--space-m) auto var(--space-l);
-  padding: 0 var(--content-padding-inline);
-  font-size: var(--body-font-size-s);
+  background-color: light-dark(rgb(161 79 43 / 4%), rgb(245 242 237 / 3%));
+  border-bottom: 1px solid light-dark(var(--color-gray-200), rgb(245 242 237 / 8%));
+  margin: 0;
+  padding: var(--space-m) var(--content-padding-inline);
 }
 
 .article .article-breadcrumb ol {
   list-style: none;
-  margin: 0;
-  padding: 0;
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-xs);
   align-items: center;
+  gap: 0;
+  margin: 0 auto;
+  padding: 0;
+  max-width: var(--grid-container-width);
+  font-size: var(--body-font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
 }
 
 .article .article-breadcrumb li:not(:last-child)::after {
-  content: '/';
-  margin-left: var(--space-xs);
-  color: var(--color-gray-500);
+  content: '›';
+  margin: 0 var(--space-m);
+  color: var(--color-gold);
+  font-size: 1rem;
+  text-transform: none;
+  letter-spacing: 0;
 }
 
 .article .article-breadcrumb a {
-  color: inherit;
+  color: light-dark(var(--color-gray-600), var(--color-muted));
   text-decoration: none;
+  transition: color 0.2s;
 }
 
 .article .article-breadcrumb a:hover,
 .article .article-breadcrumb a:focus-visible {
+  color: light-dark(var(--color-rust), var(--color-rust-bright));
   text-decoration: underline;
-  text-underline-offset: 0.2em;
-  text-decoration-thickness: 2px;
+  text-underline-offset: 0.3em;
+  text-decoration-thickness: 1px;
+}
+
+.article .article-breadcrumb li[aria-current='page'] {
+  font-family: var(--font-family-serif);
+  font-size: var(--body-font-size-s);
+  font-style: italic;
+  text-transform: none;
+  letter-spacing: 0;
+  color: light-dark(var(--color-ink), var(--color-parchment));
 }


### PR DESCRIPTION
## Summary

- **Byline**: Author in rust uppercase with letter-spacing, mid-dot separator, date in italic Garamond serif — separated from the h1 by a thin rust-tinted hairline
- **Breadcrumb**: Full-width warm-tint strip with bottom border; gold `›` chevrons with 16px padding on each side; nav links in uppercase; current page switches to italic serif
- **H2 accent bar**: Bumped from 2.5rem × 2px to 3rem × 3px for better visual presence

## Test URLs

- Before: https://main--demo--scdemos.aem.page/learn/fire/whats-fire
- After: https://feat-article-byline-breadcrumb--demo--scdemos.aem.page/learn/fire/whats-fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)