### PR TITLE
revert: site-wide styling improvements (#820947e)

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -18,8 +18,6 @@
   flex-direction: column;
   border-radius: 12px;
   overflow: hidden;
-  box-shadow: 0 2px 8px light-dark(rgb(0 0 0 / 5%), rgb(0 0 0 / 40%)),
-              0 1px 2px light-dark(rgb(0 0 0 / 6%), rgb(0 0 0 / 25%));
   transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.35s ease, border-color 0.35s ease;
 }
 

--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -63,9 +63,7 @@ a:any-link {
 main blockquote {
   margin: var(--space-2xl, 48px) 0;
   padding: var(--space-l) var(--space-xl);
-  border-left: 4px solid var(--color-gold);
-  background-color: light-dark(rgb(197 160 89 / 6%), rgb(197 160 89 / 8%));
-  border-radius: 0 8px 8px 0;
+  border-left: 3px solid var(--color-gold);
   font-family: var(--font-family-serif);
   font-size: var(--body-font-size-xl);
   font-style: italic;
@@ -107,21 +105,6 @@ main hr {
   main > .section.divider:first-child {
     padding-block-start: 0;
   }
-}
-
-/* H2 accent — thin brand-gradient bar beneath h2 in plain content sections */
-main > .section:not(.hero-container, .gradient, .ink, .rust) h2::after {
-  content: '';
-  display: block;
-  width: 2.5rem;
-  height: 2px;
-  margin-top: 0.35em;
-  background: var(--gradient-brand);
-  border-radius: 1px;
-}
-
-main > .section.center:not(.hero-container, .gradient, .ink, .rust) h2::after {
-  margin-inline: auto;
 }
 
 /* ==========================================================================

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -164,8 +164,6 @@
   --shadow-glow-gold: 0 0 40px rgb(197 160 89 / 25%);
   --shadow-lift-m: 0 20px 40px -8px rgb(0 0 0 / 15%);
   --shadow-lift-l: 0 30px 60px -12px rgb(0 0 0 / 22%);
-  --shadow-card: 0 2px 8px rgb(0 0 0 / 5%), 0 1px 2px rgb(0 0 0 / 7%);
-  --shadow-card-dark: 0 2px 12px rgb(0 0 0 / 45%), 0 1px 4px rgb(0 0 0 / 30%);
 
   /* easing presets for consistent motion */
   --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
@@ -268,11 +266,6 @@ body {
   margin: 0;
   box-sizing: border-box;
   background-color: var(--background-color);
-  background-image:
-    radial-gradient(ellipse 80% 50% at 12% 8%,
-      light-dark(rgb(197 160 89 / 9%), rgb(197 160 89 / 4%)) 0%, transparent 60%),
-    radial-gradient(ellipse 55% 40% at 88% 82%,
-      light-dark(rgb(161 79 43 / 6%), rgb(161 79 43 / 3%)) 0%, transparent 50%);
   color: var(--text-color);
   font-family: var(--body-font-family);
   font-size: var(--body-font-size-m);
@@ -311,7 +304,7 @@ h4,
 h5,
 h6 {
   margin-top: 0.8em;
-  margin-bottom: 0.4em;
+  margin-bottom: 0.25em;
   font-family: var(--heading-font-family);
   font-weight: 500;
   line-height: var(--heading-line-height);
@@ -625,23 +618,6 @@ main > .section.divider.center {
 .spacer-bottom-m { margin-bottom: var(--space-m); }
 .spacer-bottom-l { margin-bottom: var(--space-l); }
 
-/* section-metadata style=rust: bold brand accent section */
-main > .section.rust {
-  background-color: var(--color-rust);
-  color: var(--color-parchment);
-  margin: 0;
-  padding: var(--space-3xl, var(--section-block-space)) 0;
-}
-
-main > .section.rust * {
-  color: var(--color-parchment);
-}
-
-main > .section.rust a:any-link {
-  color: var(--color-parchment);
-  text-decoration-color: rgb(245 242 237 / 40%);
-}
-
 /* section-metadata style=gradient: warm brand gradient full-bleed section */
 main > .section.gradient {
   background: var(--gradient-brand);
@@ -659,9 +635,6 @@ main > .section.gradient a:any-link {
   text-decoration-color: rgb(255 255 255 / 40%);
 }
 
-/* Shared button overrides for colored sections (rust, gradient) */
-main > .section.rust a.button:any-link,
-main > .section.rust button.button,
 main > .section.gradient a.button:any-link,
 main > .section.gradient button.button {
   border-color: var(--color-parchment);
@@ -671,8 +644,6 @@ main > .section.gradient button.button {
   box-shadow: none;
 }
 
-main > .section.rust a.button:any-link:hover,
-main > .section.rust button.button:hover,
 main > .section.gradient a.button:any-link:hover,
 main > .section.gradient button.button:hover {
   background-color: var(--color-parchment);
@@ -691,28 +662,6 @@ main > .section.ink {
 
 main > .section.ink * {
   color: var(--color-parchment);
-}
-
-/* section-metadata style=warm: atmospheric warm tint with heritage diamond mesh */
-main > .section.warm {
-  background-color: light-dark(#f2ead8, #0e1812);
-  background-image:
-    repeating-linear-gradient(
-      45deg,
-      light-dark(rgb(161 79 43 / 4%), rgb(245 242 237 / 2%)) 0,
-      light-dark(rgb(161 79 43 / 4%), rgb(245 242 237 / 2%)) 1px,
-      transparent 1px,
-      transparent 12px
-    ),
-    repeating-linear-gradient(
-      -45deg,
-      light-dark(rgb(161 79 43 / 4%), rgb(245 242 237 / 2%)) 0,
-      light-dark(rgb(161 79 43 / 4%), rgb(245 242 237 / 2%)) 1px,
-      transparent 1px,
-      transparent 12px
-    );
-  margin: 0;
-  padding: var(--space-3xl, var(--section-block-space)) 0;
 }
 
 /* gradient-text utility: apply to any heading or span for brand gradient text */


### PR DESCRIPTION
## Summary

Reverts commit 820947ebf3000d6a6967549ad6c6b0472a1e490c — *feat(styles): site-wide styling improvements for atmosphere, typography, and depth* (merged via #47).

Restores the following files to their pre-820947e state:
- `styles/styles.css` — removes body ambient gradients, heading margin change, shadow tokens, `.section.rust`, `.section.warm`
- `styles/lazy-styles.css` — removes H2 accent bar, blockquote enhancements
- `blocks/cards/cards.css` — removes resting card box-shadow

🤖 Generated with [Claude Code](https://claude.com/claude-code)