### PR TITLE
fix(article): match breadcrumb width to prose reading width

### DIFF
--- a/templates/article/article.css
+++ b/templates/article/article.css
@@ -57,7 +57,7 @@
   gap: 0;
   margin: 0 auto;
   padding: 0;
-  max-width: var(--grid-container-width);
+  max-width: 720px;
   font-size: var(--body-font-size-xs);
   text-transform: uppercase;
   letter-spacing: 1.5px;


### PR DESCRIPTION
## Summary

Sets the breadcrumb `ol` `max-width` to `720px` to match the article prose `default-content-wrapper` constraint, keeping the breadcrumb text visually flush with the article body content.

## Test URLs

- Before: https://main--demo--scdemos.aem.page/learn/fire/whats-fire
- After: https://fix-article-breadcrumb-width--demo--scdemos.aem.page/learn/fire/whats-fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)