### PR TITLE
fix(cards): add semantic article wrapper; remove article prose max-width

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -29,6 +29,11 @@
   border-color: light-dark(var(--color-gold), rgb(197 160 89 / 45%));
 }
 
+/* Article wrapper — layout-invisible so the card link remains the direct flex child */
+.cards > ul > li > article {
+  display: contents;
+}
+
 /* Card link */
 .cards .cards-card-link {
   display: flex;

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -165,6 +165,10 @@ function decorateDefault(block) {
       }
     }
 
+    const article = createTag('article');
+    while (li.firstChild) article.append(li.firstChild);
+    li.append(article);
+
     ul.append(li);
   });
 

--- a/templates/article/article.css
+++ b/templates/article/article.css
@@ -57,7 +57,7 @@
   gap: 0;
   margin: 0 auto;
   padding: 0;
-  max-width: 720px;
+  max-width: var(--grid-container-width);
   font-size: var(--body-font-size-xs);
   text-transform: uppercase;
   letter-spacing: 1.5px;
@@ -95,12 +95,3 @@
   color: light-dark(var(--color-ink), var(--color-parchment));
 }
 
-/* ==========================================================================
-   Prose reading width — constrain default-content-wrapper to a comfortable
-   line length (~72 characters) for long-form article text.
-   ========================================================================== */
-
-.article .article-body .default-content-wrapper {
-  max-width: 720px;
-  margin-inline: auto;
-}


### PR DESCRIPTION
## Summary

- Wraps the content of each default card in an `<article>` element for semantic correctness. The wrapper uses `display: contents` in CSS so it is layout-invisible — the card link remains the direct flex child of the `<li>` and all existing hover/shadow behaviour is unchanged.
- Removes the prose line-length constraint (`max-width: 720px` on `.default-content-wrapper`) that was previously scoped to article pages, as the broader approach to line-length control is still being evaluated.

## Test URLs

- Before: https://main--demo--scdemos.aem.page/
- After: https://fix-article-breadcrumb-width--demo--scdemos.aem.page/

🤖 Generated with [Claude Code](https://claude.com/claude-code)