### PR TITLE
fix(typography): correct heading scale

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -129,6 +129,7 @@
   --heading-font-size-m: 22.78px;
   --heading-font-size-s: 20.25px;
   --heading-font-size-xs: 18px;
+  --heading-font-size-xxs: 16px;
   --heading-line-height: 1.15;
 
   /* body sizes */
@@ -185,6 +186,8 @@
 @media (width >= 600px) {
   :root,
   :host {
+    --heading-font-size-xxl: 44px;
+    --heading-font-size-xl: 36px;
     --content-padding-inline: var(--space-l);
     --main-block-space: var(--space-xl);
     --section-block-space: var(--space-xl);
@@ -331,7 +334,7 @@ h2 {
 h3 { font-size: var(--heading-font-size-m); }
 h4 { font-size: var(--heading-font-size-s); }
 h5 { font-size: var(--heading-font-size-xs); }
-h6 { font-size: var(--heading-font-size-xs); }
+h6 { font-size: var(--heading-font-size-xxs); }
 
 @media (width >= 600px) {
   h3 { font-size: var(--heading-font-size-l); }
@@ -339,9 +342,6 @@ h6 { font-size: var(--heading-font-size-xs); }
   h5 { font-size: var(--heading-font-size-s); }
 }
 
-@media (width >= 1200px) {
-  h3 { font-size: var(--heading-font-size-xl); }
-}
 
 p,
 dl,


### PR DESCRIPTION
## Summary

- **H3 = H2 at desktop (bug fix):** The `@media (width >= 1200px)` override was setting H3 to `--heading-font-size-xl` (48px) — identical to H2. Removed the override; H3 correctly inherits `--heading-font-size-l` (32px) from the 900px token update.
- **H1/H2 intermediate step:** Added 44px/36px values for `xxl`/`xl` tokens at the 600px breakpoint. Previously H1 jumped from 32px (mobile) directly to 64px at 900px with no intermediate size. Now: 32px → 44px → 64px.
- **H5/H6 differentiation:** Added `--heading-font-size-xxs: 16px` token and applied it to H6. Previously H5 and H6 were both 18px at every breakpoint.

## Resulting scale

| Level | < 600px | 600–899px | 900px+ |
|---|---|---|---|
| H1 | 32px | 44px | 64px |
| H2 | 28px | 36px | 48px |
| H3 | 22px | 25px | **32px** (was 48px at 1200px+) |
| H4 | 20px | 22px | 24px |
| H5 | 18px | 20px | 20px |
| H6 | **16px** | 16px | 16px |

## Test URLs

- Before: https://main--demo--scdemos.aem.page/
- After: https://fix-heading-scale--demo--scdemos.aem.page/

🤖 Generated with [Claude Code](https://claude.com/claude-code)