### PR TITLE
fix: skip martech in quick-edit mode

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -197,7 +197,7 @@ async function loadEager(doc) {
   // Consent stub — wire to real CMP later; true for demo
   const isConsentGiven = true;
 
-  const martechLoadedPromise = initMartech(
+  const martechLoadedPromise = !IS_QUICK_EDIT && initMartech(
     {
       datastreamId: 'd73be188-bc37-4ede-a5da-8aa7cd1e343b',
       orgId: '138A07885EE042D20A495CFA@AdobeOrg',
@@ -230,7 +230,7 @@ async function loadEager(doc) {
     decorateMain(main);
     document.body.classList.add('appear');
     await Promise.all([
-      martechLoadedPromise.then(martechEager),
+      martechLoadedPromise && martechLoadedPromise.then(martechEager),
       loadSection(main.querySelector('.section'), async (s) => {
         await waitForFirstImage(s);
         await loadFragments(s);
@@ -274,7 +274,7 @@ async function loadLazy(doc) {
   if (hash && element) element.scrollIntoView();
 
   loadFooter(footerEl);
-  await martechLazy();
+  if (!IS_QUICK_EDIT) await martechLazy();
 
   /* Scroll reveal: sections below the viewport animate in as they enter */
   if (main && 'IntersectionObserver' in window) {
@@ -353,14 +353,12 @@ async function loadLazy(doc) {
   }
 }
 
-(() => {
-  const hasQE = new URL(window.location.href).searchParams.has('quick-edit');
-  if (hasQE) import('../tools/quick-edit/quick-edit.js').then((mod) => mod.default());
-})();
+const IS_QUICK_EDIT = new URL(window.location.href).searchParams.has('quick-edit');
+if (IS_QUICK_EDIT) import('../tools/quick-edit/quick-edit.js').then((mod) => mod.default());
 
 function loadDelayed() {
   window.setTimeout(() => {
-    martechDelayed();
+    if (!IS_QUICK_EDIT) martechDelayed();
     import('./delayed.js');
   }, 3000);
 }


### PR DESCRIPTION
Gate initMartech/martechEager, martechLazy, and martechDelayed behind IS_QUICK_EDIT so no Web SDK, Launch, or Target calls fire when the ?quick-edit param is present. Hoists the existing hasQE IIFE to a module-level constant reused across all three load phases.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--demo--scdemos.aem.live/
- After: https://martech-quickedit--demo--scdemos.aem.live/
