### PR TITLE
feat(martech): vendor-side updates for Form-Based Target activities + non-visual selector guard

### DIFF
--- a/plugins/martech/README.md
+++ b/plugins/martech/README.md
@@ -32,6 +32,7 @@ The AEM Marketing Technology plugin helps you quickly set up a complete MarTech 
   - [Consent Management](#consent-management)
       - [Integrating with AEM Consent Banner Block](#integrating-with-aem-consent-banner-block)
       - [Integrating with OneTrust](#integrating-with-onetrust)
+  - [Working with Form-Based Activities](#working-with-form-based-activities)
   - [Working with Dynamic Content (SPAs)](#working-with-dynamic-content-spas)
   - [FAQ](#faq)
     - [Why not use the default Adobe Launch approach?](#why-not-use-the-default-adobe-launch-approach)
@@ -170,7 +171,7 @@ async function loadEager(doc) {
     {
       datastreamId: /* your datastream id here */,
       orgId: /* your IMS org id here */,
-      // The `debugEnabled` flag is automatically set to true on localhost and .page URLs.
+      // The `debugEnabled` flag is automatically set to true on localhost, .page, and .aem.network URLs.
       // The `defaultConsent` is automatically set to "pending".
       onBeforeEventSend: (payload) => {
         // This callback allows you to modify the payload before it's sent.
@@ -184,6 +185,10 @@ async function loadEager(doc) {
     {
       personalization: !!getMetadata('target') && isConsentGiven,
       launchUrls: [/* your Launch script URLs here */],
+      // For Form-Based activities at named mboxes, add the scope(s) here.
+      // decisionScopes: ['target-global-mbox'],
+      // If those offers don't embed a CSS selector, add a fallback map.
+      // propositionMetadata: { 'target-global-mbox': { selector: 'main h2', actionType: 'replaceHtml' } },
       // See the API Reference for all available options.
     },
   );
@@ -253,6 +258,8 @@ Initializes the library. This should be called once in `loadEager`.
   - `personalizationTimeout` `{Number}`: Timeout in ms for personalization. Default: `1000`.
   - `trackPageView` `{Boolean}`: Whether to automatically send a page view event on page activation. When `false`, the library sends a `decisioning.propositionDisplay` event instead, so proposition display is still reported to Target without triggering an extra page view. Set to `false` if this is already handled separately in the page. Default: `true`.
   - `shouldProcessEvent` `{Function}`: A function that receives a data layer event payload and returns `false` to prevent it from being sent.
+  - `decisionScopes` `{String[]}`: Additional decision scopes to request beyond the default `__view__` scope. Required for Form-Based activities targeting named mboxes (e.g. `['target-global-mbox']`). Default: `[]`.
+  - `propositionMetadata` `{Object}`: Selector fallback map for Form-Based HTML offers that do not carry a built-in CSS selector (e.g. raw HTML offers created manually in Target). Keys are decision scope names; values are `{ selector, actionType }` objects where `actionType` is `'setHtml'`, `'replaceHtml'` (default), or `'appendHtml'`. DA "Send to Target" offers embed their own selector and do not need an entry here. Default: `{}`.
 
 ---
 
@@ -339,6 +346,50 @@ function consentEventHandler(ev) {
 }
 window.addEventListener('consent.onetrust', consentEventHandler);
 ```
+
+## Working with Form-Based Activities
+
+Adobe Target Form-Based activities (offers created in the Target UI rather than the Visual Experience Composer) require two additional configuration steps because the Web SDK does not fetch named mbox propositions by default.
+
+### Step 1 — Request the mbox scope
+
+Add the mbox name(s) to `decisionScopes` in your `initMartech` call:
+
+```js
+initMartech(webSDKConfig, {
+  personalization: true,
+  decisionScopes: ['target-global-mbox'],
+});
+```
+
+Without this, the Web SDK only fetches `__view__` (VEC) propositions and Form-Based activities at named mboxes are silently ignored.
+
+### Step 2 — Provide a selector fallback (if needed)
+
+Offers sent from **Document Authoring via "Send to Target"** embed their own CSS selector in the offer data — no further configuration is required for those.
+
+For **raw HTML offers** created manually in the Target UI (which have no built-in selector), provide a `propositionMetadata` fallback map:
+
+```js
+initMartech(webSDKConfig, {
+  personalization: true,
+  decisionScopes: ['target-global-mbox'],
+  propositionMetadata: {
+    'target-global-mbox': {
+      // CSS selector of the element the offer content targets
+      selector: 'main .hero',
+      // 'setHtml'     — replace the inner HTML of the matched element (preserves the element)
+      // 'replaceHtml' — replace the matched element itself with the offer content (default)
+      // 'appendHtml'  — append the offer content as children of the matched element
+      actionType: 'setHtml',
+    },
+  },
+});
+```
+
+The same `propositionMetadata` field also acts as a **rescue override for misconfigured VEC offers**: if a dom-action item arrives with a non-visual selector (`head`, `body`, or `html`) — which can happen when a DA offer is re-sent without updating its selector — the plugin reroutes it through the matching `propositionMetadata` entry and applies it directly. Items with no override (or whose override selector is itself `head`/`body`/`html`) are dropped with a debug-mode warning to prevent unintended document-chrome mutations.
+
+> **Reporting note:** When the rescue override path is used, the plugin manually fires a `decisioning.propositionDisplay` event so Target Activity reporting still records an impression for the delivered offer.
 
 ## Working with Dynamic Content (SPAs)
 

--- a/plugins/martech/src/index.js
+++ b/plugins/martech/src/index.js
@@ -441,21 +441,27 @@ function applyHtmlAction(target, content, actionType) {
   }
 }
 
+// Cap retries for direct-inject entries so a typo'd or never-rendering selector can't
+// keep generating querySelector calls for the life of the page.
+const DIRECT_INJECT_MAX_ATTEMPTS = 20;
+
 /**
- * Fires a `decisioning.propositionDisplay` event so Target Activity reporting records an
- * impression for offers we applied outside the alloy pipeline (non-visual dom-action fallback).
+ * Fires a single `decisioning.propositionDisplay` event covering one or more propositions
+ * we applied outside the alloy pipeline (non-visual dom-action fallback), so Target Activity
+ * reporting still records an impression.
  */
-function reportPropositionDisplay(instanceName, proposition) {
+function reportPropositionDisplay(instanceName, propositions) {
+  if (!propositions.length) return;
   window[instanceName]('sendEvent', {
     xdm: {
       eventType: 'decisioning.propositionDisplay',
       _experience: {
         decisioning: {
-          propositions: [{
-            id: proposition.id,
-            scope: proposition.scope,
-            scopeDetails: proposition.scopeDetails,
-          }],
+          propositions: propositions.map((p) => ({
+            id: p.id,
+            scope: p.scope,
+            scopeDetails: p.scopeDetails,
+          })),
           propositionEventType: { display: 1 },
         },
       },
@@ -490,7 +496,10 @@ async function applyPropositions(instanceName) {
   // VEC offer — alloy would inject into <head>/<body>/<html>. Pull them out of the alloy pipeline
   // and apply them via propositionMetadata override (or drop them) instead. Also drop
   // html-content-item items that have no resolvable selector so they aren't retried every tick.
+  // Build the html-content-item metadata map up front so the per-tick callback doesn't have to
+  // re-walk the propositions tree.
   let directInjectQueue = [];
+  const htmlContentMetadata = {};
   let propositions = window.structuredClone(renderDecisionResponse.propositions)
     .filter((p) => p.items.some(
       (i) => i.schema === SCHEMA_DOM_ACTION || i.schema === SCHEMA_HTML_CONTENT_ITEM,
@@ -514,12 +523,17 @@ async function applyPropositions(instanceName) {
             content: item.data.content,
             selector: override.selector,
             actionType: override.actionType || 'replaceHtml',
+            attempts: 0,
           });
           return null;
         }
-        if (item.schema === SCHEMA_HTML_CONTENT_ITEM && !resolveHtmlContentTarget(item, p.scope)) {
-          debug('martech', `dropping html-content-item with no resolvable selector for scope "${p.scope}"`);
-          return null;
+        if (item.schema === SCHEMA_HTML_CONTENT_ITEM) {
+          const target = resolveHtmlContentTarget(item, p.scope);
+          if (!target) {
+            debug('martech', `dropping html-content-item with no resolvable selector for scope "${p.scope}"`);
+            return null;
+          }
+          htmlContentMetadata[p.scope] = target;
         }
         return item;
       }).filter(Boolean),
@@ -527,10 +541,12 @@ async function applyPropositions(instanceName) {
     .filter((p) => p.items.length > 0);
   onDecoratedElement(async () => {
     // Direct injection for dom-action items alloy cannot place (non-visual selector override).
-    // Re-queue items whose target hasn't been decorated yet so later mutation ticks can retry.
+    // Re-queue items whose target hasn't been decorated yet so later mutation ticks can retry,
+    // up to DIRECT_INJECT_MAX_ATTEMPTS — past that we assume the selector is wrong and drop it.
     if (directInjectQueue.length) {
       const pending = directInjectQueue;
       directInjectQueue = [];
+      const justInjected = [];
       pending.forEach((entry) => {
         let target;
         try {
@@ -540,27 +556,25 @@ async function applyPropositions(instanceName) {
           return;
         }
         if (!target) {
+          entry.attempts += 1;
+          if (entry.attempts >= DIRECT_INJECT_MAX_ATTEMPTS) {
+            debug('martech', `dropping direct-inject entry after ${entry.attempts} attempts — selector "${entry.selector}" never matched`);
+            return;
+          }
           directInjectQueue.push(entry);
           return;
         }
         applyHtmlAction(target, entry.content, entry.actionType);
-        reportPropositionDisplay(instanceName, entry.proposition);
+        justInjected.push(entry.proposition);
       });
+      reportPropositionDisplay(instanceName, justInjected);
     }
     if (!propositions.length) {
       return;
     }
-    const metadata = {};
-    propositions.forEach((p) => {
-      p.items.forEach((item) => {
-        if (item.schema !== SCHEMA_HTML_CONTENT_ITEM) return;
-        const target = resolveHtmlContentTarget(item, p.scope);
-        if (target) metadata[p.scope] = target;
-      });
-    });
     const applyOptions = { propositions };
-    if (Object.keys(metadata).length) {
-      applyOptions.metadata = metadata;
+    if (Object.keys(htmlContentMetadata).length) {
+      applyOptions.metadata = htmlContentMetadata;
     }
     const appliedPropositions = await window[instanceName](
       'applyPropositions',

--- a/plugins/martech/src/index.js
+++ b/plugins/martech/src/index.js
@@ -50,6 +50,9 @@
  */
 const SCHEMA_DOM_ACTION = 'https://ns.adobe.com/personalization/dom-action';
 const SCHEMA_HTML_CONTENT_ITEM = 'https://ns.adobe.com/personalization/html-content-item';
+// Selectors that target the document chrome rather than visible content. If a dom-action item
+// arrives with one of these, alloy's applyPropositions injects directly into <head>/<body>/<html>.
+const NON_VISUAL_SELECTORS = new Set(['head', 'body', 'html']);
 
 export const DEFAULT_CONFIG = {
   analytics: true,
@@ -72,6 +75,13 @@ let alloyConfig;
 let isAlloyConfigured = false;
 const pendingAlloyCommands = [];
 const pendingDatalayerEvents = [];
+
+const debug = (label = 'martech', ...args) => {
+  if (alloyConfig?.debugEnabled) {
+    // eslint-disable-next-line no-console
+    console.debug.call(null, `[${label}]`, ...args);
+  }
+};
 
 /**
  * Triggers the callback when the page is actually activated,
@@ -398,6 +408,62 @@ export async function updateUserConsent(consent) {
 let response;
 
 /**
+ * Resolves the target selector and actionType for a Form-Based html-content-item.
+ * Priority: selector embedded in item data (DA "Send to Target" offers carry this automatically)
+ * > propositionMetadata config fallback (manually created raw HTML offers).
+ * @returns {{selector: String, actionType: String}|null} null when no selector can be resolved
+ */
+function resolveHtmlContentTarget(item, scope) {
+  const selector = item.data?.selector || config.propositionMetadata?.[scope]?.selector;
+  if (!selector) return null;
+  const actionType = item.data?.actionType
+    || config.propositionMetadata?.[scope]?.actionType
+    || 'replaceHtml';
+  return { selector, actionType };
+}
+
+/**
+ * Applies an HTML offer's content to a target element using alloy's actionType vocabulary.
+ * Mirrors what alloy itself does for setHtml/replaceHtml/appendHtml so the direct-injection
+ * fallback behaves identically to the alloy-handled path.
+ */
+function applyHtmlAction(target, content, actionType) {
+  const parser = new DOMParser();
+  const parsed = parser.parseFromString(content, 'text/html');
+  const nodes = [...parsed.body.childNodes];
+  if (actionType === 'appendHtml') {
+    target.append(...nodes);
+  } else if (actionType === 'setHtml') {
+    target.replaceChildren(...nodes);
+  } else {
+    // replaceHtml (alloy semantics: replace the element itself)
+    target.replaceWith(...nodes);
+  }
+}
+
+/**
+ * Fires a `decisioning.propositionDisplay` event so Target Activity reporting records an
+ * impression for offers we applied outside the alloy pipeline (non-visual dom-action fallback).
+ */
+function reportPropositionDisplay(instanceName, proposition) {
+  window[instanceName]('sendEvent', {
+    xdm: {
+      eventType: 'decisioning.propositionDisplay',
+      _experience: {
+        decisioning: {
+          propositions: [{
+            id: proposition.id,
+            scope: proposition.scope,
+            scopeDetails: proposition.scopeDetails,
+          }],
+          propositionEventType: { display: 1 },
+        },
+      },
+    },
+  }).catch(() => { /* reporting failure shouldn't break the page */ });
+}
+
+/**
  * Fetching propositions from the backend and applying the propositions as the AEM EDS page loads
  * its content async.
  * Documentation:
@@ -405,30 +471,6 @@ let response;
  * @param {String} instanceName The name of the instance in the blobal scope
  * @returns a promise that the propositions were retrieved and will be applied as the page renders
  */
-/**
- * Builds the metadata object required by alloy's applyPropositions for
- * html-content-item propositions (Form-Based HTML offers without built-in selectors).
- * Priority: selector embedded in item data (DA "Send to Target" offers) > propositionMetadata
- * config fallback (manually created raw HTML offers).
- * @param {Array} propositions
- * @returns {Object} metadata keyed by scope — empty if no html-content-item items need mapping
- */
-function buildHtmlContentMetadata(propositions) {
-  const metadata = {};
-  propositions.forEach((p) => {
-    p.items.forEach((item) => {
-      if (item.schema !== SCHEMA_HTML_CONTENT_ITEM) return;
-      const selector = item.data?.selector || config.propositionMetadata?.[p.scope]?.selector;
-      if (!selector) return;
-      const actionType = item.data?.actionType
-        || config.propositionMetadata?.[p.scope]?.actionType
-        || 'replaceHtml';
-      metadata[p.scope] = { selector, actionType };
-    });
-  });
-  return metadata;
-}
-
 async function applyPropositions(instanceName) {
   // Get the decisions, but don't render them automatically
   // so we can hook up into the AEM EDS page load sequence
@@ -444,11 +486,11 @@ async function applyPropositions(instanceName) {
   if (!renderDecisionResponse?.propositions) {
     return [];
   }
-  // dom-action items targeting non-visual elements (head/body/html) have a wrong selector —
-  // alloy validates dom-action propositions against its edge response cache by ID and ignores
-  // any selector we pass. Collect these for direct DOM injection and exclude from alloy entirely.
-  const NON_VISUAL_SELECTORS = new Set(['head', 'body', 'html']);
-  const directInjectItems = [];
+  // dom-action items targeting a non-visual element (head/body/html) are usually a misconfigured
+  // VEC offer — alloy would inject into <head>/<body>/<html>. Pull them out of the alloy pipeline
+  // and apply them via propositionMetadata override (or drop them) instead. Also drop
+  // html-content-item items that have no resolvable selector so they aren't retried every tick.
+  let directInjectQueue = [];
   let propositions = window.structuredClone(renderDecisionResponse.propositions)
     .filter((p) => p.items.some(
       (i) => i.schema === SCHEMA_DOM_ACTION || i.schema === SCHEMA_HTML_CONTENT_ITEM,
@@ -459,13 +501,24 @@ async function applyPropositions(instanceName) {
         if (item.schema === SCHEMA_DOM_ACTION
           && NON_VISUAL_SELECTORS.has(item.data?.selector)) {
           const override = config.propositionMetadata?.[p.scope];
-          if (override?.selector) {
-            directInjectItems.push({
-              content: item.data.content,
-              selector: override.selector,
-              actionType: override.actionType || 'replaceHtml',
-            });
+          if (!override?.selector) {
+            debug('martech', `dropping non-visual dom-action item with no propositionMetadata override for scope "${p.scope}"`);
+            return null;
           }
+          if (NON_VISUAL_SELECTORS.has(override.selector)) {
+            debug('martech', `ignoring propositionMetadata override for scope "${p.scope}": selector "${override.selector}" is non-visual`);
+            return null;
+          }
+          directInjectQueue.push({
+            proposition: { id: p.id, scope: p.scope, scopeDetails: p.scopeDetails },
+            content: item.data.content,
+            selector: override.selector,
+            actionType: override.actionType || 'replaceHtml',
+          });
+          return null;
+        }
+        if (item.schema === SCHEMA_HTML_CONTENT_ITEM && !resolveHtmlContentTarget(item, p.scope)) {
+          debug('martech', `dropping html-content-item with no resolvable selector for scope "${p.scope}"`);
           return null;
         }
         return item;
@@ -473,25 +526,38 @@ async function applyPropositions(instanceName) {
     }))
     .filter((p) => p.items.length > 0);
   onDecoratedElement(async () => {
-    // Direct injection for dom-action items alloy cannot place (non-visual selector override)
-    while (directInjectItems.length) {
-      const { content, selector, actionType } = directInjectItems.shift();
-      const target = document.querySelector(selector);
-      if (target) {
-        const parser = new DOMParser();
-        const parsed = parser.parseFromString(content, 'text/html');
-        const nodes = [...parsed.body.childNodes];
-        if (actionType === 'appendHtml') {
-          target.append(...nodes);
-        } else {
-          target.replaceWith(...nodes);
+    // Direct injection for dom-action items alloy cannot place (non-visual selector override).
+    // Re-queue items whose target hasn't been decorated yet so later mutation ticks can retry.
+    if (directInjectQueue.length) {
+      const pending = directInjectQueue;
+      directInjectQueue = [];
+      pending.forEach((entry) => {
+        let target;
+        try {
+          target = document.querySelector(entry.selector);
+        } catch (err) {
+          debug('martech', `propositionMetadata selector "${entry.selector}" is invalid: ${err.message}`);
+          return;
         }
-      }
+        if (!target) {
+          directInjectQueue.push(entry);
+          return;
+        }
+        applyHtmlAction(target, entry.content, entry.actionType);
+        reportPropositionDisplay(instanceName, entry.proposition);
+      });
     }
     if (!propositions.length) {
       return;
     }
-    const metadata = buildHtmlContentMetadata(propositions);
+    const metadata = {};
+    propositions.forEach((p) => {
+      p.items.forEach((item) => {
+        if (item.schema !== SCHEMA_HTML_CONTENT_ITEM) return;
+        const target = resolveHtmlContentTarget(item, p.scope);
+        if (target) metadata[p.scope] = target;
+      });
+    });
     const applyOptions = { propositions };
     if (Object.keys(metadata).length) {
       applyOptions.metadata = metadata;
@@ -596,13 +662,6 @@ export async function initMartech(webSDKConfig, martechConfig = {}) {
   }
   return Promise.resolve();
 }
-
-const debug = (label = 'martech', ...args) => {
-  if (alloyConfig.debugEnabled) {
-    // eslint-disable-next-line no-console
-    console.debug.call(null, `[${label}]`, ...args);
-  }
-};
 
 export function initRumTracking(sampleRUM, options = {}) {
   // Load the RUM enhancer so we can map all RUM events even on non-sampled pages
@@ -724,7 +783,10 @@ export async function martechLazy() {
       });
     }
   } else if (!config.performanceOptimized) {
-    const renderDecisionResponse = await sendEvent({ renderDecisions: true, decisionScopes: ['__view__'] });
+    const renderDecisionResponse = await sendEvent({
+      renderDecisions: true,
+      decisionScopes: [...new Set(['__view__', ...(config.decisionScopes || [])])],
+    });
     response = renderDecisionResponse;
     document.body.style.visibility = null;
     // Automatically report displayed propositions


### PR DESCRIPTION
## Summary

Updates our vendored `plugins/martech/` to support Form-Based Adobe Target activities and to defend against misconfigured VEC offers that deliver with non-visual selectors. Tracks the upstream PR [adobe-rnd/aem-martech#17](https://github.com/adobe-rnd/aem-martech/pull/17) — the `src/index.js` and `README.md` in this PR are byte-identical to the upstream branch.

### What changed

**Form-Based HTML offers (`html-content-item` schema)**
- New `propositionMetadata` config: scope → `{ selector, actionType }` fallback map for raw HTML offers that don't embed a selector. DA "Send to Target" offers already carry their own selector and need no entry here.
- HTML-content items with no resolvable selector are dropped during the filter pass with a `debug()` log so they aren't retried every observer tick.
- The html-content metadata map is built once during the filter pass and reused across observer ticks.

**Non-visual selector guard with direct-injection rescue path**
- A module-level `NON_VISUAL_SELECTORS` set (`head`/`body`/`html`) catches `dom-action` items that alloy would otherwise inject into the document chrome. Affected items are routed out of the alloy pipeline (alloy ignores in-place selector overrides for cached propositions) and applied via a shared `applyHtmlAction()` helper that mirrors alloy's `setHtml` / `replaceHtml` / `appendHtml` semantics.
- The rescue path uses `propositionMetadata` for the override selector. **Override selectors that are themselves `head`/`body`/`html` are rejected** so misconfiguration can't bypass the guard.
- Items whose target isn't yet in the DOM are re-queued for later observer ticks. Retries are capped at `DIRECT_INJECT_MAX_ATTEMPTS` (20) so a typo'd or never-matching selector eventually gets dropped with a debug log instead of running `querySelector` on every body mutation for the life of the page.
- `document.querySelector` is wrapped in `try/catch` so a malformed override selector can't crash the alloy pipeline.
- After a successful direct injection the plugin fires a **single batched** `decisioning.propositionDisplay` event covering every proposition applied on that observer tick, so Target Activity reporting still records impressions.

**`decisionScopes` config option**
- New `decisionScopes: []` in `DEFAULT_CONFIG`. Without this, the Web SDK only fetches `__view__` propositions and Form-Based activities at named mboxes are silently never requested.
- Wired into both the `performanceOptimized` `applyPropositions` `sendEvent` call and the `martechLazy` `renderDecisions: true` path (with `__view__` prepended and de-duplicated via `Set`).

**`debugEnabled` includes `.aem.network`**
- Alloy console output is now visible on `.aem.network` QA preview environments.

### Documentation

- `plugins/martech/README.md` has a new "Working with Form-Based Activities" section that documents both new config options, with an example using `setHtml` and inline comments explaining the three `actionType` values.
- The rescue-override behavior, override rejection, and impression-reporting trade-off are documented inline.

## Test URLs:

Before: https://main--demo--scdemos.aem.live/
After: https://martech--demo--scdemos.aem.live/

Made with [Cursor](https://cursor.com)