### PR TITLE
feat: fragment localization with locale-aware loading and #_dnt support

### DIFF
--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -33,17 +33,15 @@ export async function loadFragment(path) {
     const { prefix } = getLocale();
     const localizedPath = (!dnt && prefix) ? `${prefix}${cleanPath}` : cleanPath;
 
-    console.log('Loading fragment: path=%s, cleanPath=%s, localizedPath=%s, dnt=%s', path, cleanPath, localizedPath, dnt);
-
     let resp = await fetch(`${localizedPath}.plain.html`);
     let resolvedPath = localizedPath;
     if (!resp.ok && prefix && !dnt) {
-      console.log('Fragment not found for localized path: %s, loading default path: %s', localizedPath, cleanPath)
+      console.log('Fragment not found for localized path: %s', localizedPath)
 
       resp = await fetch(`${cleanPath}.plain.html`);
       resolvedPath = cleanPath;
     } else {
-      console.log('Loaded fragment for localized path: %s', localizedPath);
+      console.log('Found localized fragment for path: %s', localizedPath);
     }
 
     if (resp.ok) {

--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -12,24 +12,47 @@ import {
   loadSections,
 } from '../../scripts/aem.js';
 
+import { getLocale } from '../../scripts/shared.js';
 import dynamicBlocks from '../dynamic/index.js';
 
+/** Hash that opts out of localizing fragment URLs. */
+const DNT_HASH = '#_dnt';
+
 /**
- * Loads a fragment.
- * @param {string} path The path to the fragment
+ * Loads a fragment, trying the locale-prefixed path first and falling back to the original.
+ * Example: on /de/page, /fragments/nav → tries /de/fragments/nav then /fragments/nav.
+ * Append #_dnt to the path to skip localization for a specific fragment.
+ * @param {string} path The path to the fragment (may include #_dnt hash)
  * @returns {Promise<HTMLElement>} The root element of the fragment
  */
 export async function loadFragment(path) {
   if (path && path.startsWith('/') && !path.startsWith('//')) {
-    const resp = await fetch(`${path}.plain.html`);
+    const dnt = path.includes(DNT_HASH);
+    const cleanPath = path.replace(DNT_HASH, '').replace(/#$/, '');
+
+    const { prefix } = getLocale();
+    const localizedPath = (!dnt && prefix) ? `${prefix}${cleanPath}` : cleanPath;
+
+    console.log('Loading fragment: path=%s, cleanPath=%s, localizedPath=%s, dnt=%s', path, cleanPath, localizedPath, dnt);
+
+    let resp = await fetch(`${localizedPath}.plain.html`);
+    let resolvedPath = localizedPath;
+    if (!resp.ok && prefix && !dnt) {
+      console.log('Fragment not found for localized path: %s, loading default path: %s', localizedPath, cleanPath)
+
+      resp = await fetch(`${cleanPath}.plain.html`);
+      resolvedPath = cleanPath;
+    } else {
+      console.log('Loaded fragment for localized path: %s', localizedPath);
+    }
+
     if (resp.ok) {
       const main = document.createElement('main');
       main.innerHTML = await resp.text();
 
-      // reset base path for media to fragment base
       const resetAttributeBase = (tag, attr) => {
         main.querySelectorAll(`${tag}[${attr}^="./media_"]`).forEach((elem) => {
-          elem[attr] = new URL(elem.getAttribute(attr), new URL(path, window.location)).href;
+          elem[attr] = new URL(elem.getAttribute(attr), new URL(resolvedPath, window.location)).href;
         });
       };
       resetAttributeBase('img', 'src');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -20,7 +20,7 @@ import {
 import {
   initMartech, martechEager, martechLazy, martechDelayed,
 } from '../plugins/martech/src/index.js';
-import { getAllMetadata } from './shared.js';
+import { getAllMetadata, getLocale } from './shared.js';
 import { initPageSchemas } from './schema.js';
 import dynamicBlocks from '../blocks/dynamic/index.js';
 
@@ -111,8 +111,8 @@ async function loadFragments(section) {
   const { loadFragment } = await import('../blocks/fragment/fragment.js');
   await Promise.all(fragments.map(async (a) => {
     try {
-      const { pathname } = new URL(a.href);
-      const frag = await loadFragment(pathname);
+      const { pathname, hash } = new URL(a.href);
+      const frag = await loadFragment(`${pathname}${hash}`);
       a.parentElement.replaceWith(...frag.children);
     } catch (error) {
       console.error('Fragment loading failed', error);
@@ -190,7 +190,7 @@ async function loadTemplate(main, template) {
 }
 
 async function loadEager(doc) {
-  document.documentElement.lang = 'en';
+  getLocale();
   decorateTemplateAndTheme();
   applyTheme();
 

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -28,8 +28,6 @@ export function getLocale(locales = LOCALES) {
   const prefix = matches.sort((a, b) => b.length - a.length)[0] || '';
   const locale = locales[prefix] || locales[''];
 
-  console.log('Locale: %s', JSON.stringify(locale));
-
   document.documentElement.lang = locale?.lang || 'en';
   return { prefix, ...locale };
 }

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -1,6 +1,40 @@
 import { getMetadata } from './aem.js';
 
 /**
+ * Locale config: maps URL prefix to locale metadata.
+ * Root locale uses empty string key.
+ * Add or remove entries to match the site's language support.
+ */
+export const LOCALES = {
+  '': { lang: 'en' },
+  '/de': { lang: 'de' },
+  '/es': { lang: 'es' },
+  '/fr': { lang: 'fr' },
+  '/ja': { lang: 'ja' },
+  '/zh': { lang: 'zh' },
+  '/hi': { lang: 'hi' }
+};
+
+/**
+ * Detect the current locale from the URL pathname and apply its lang to <html>.
+ * @param {Object} [locales] - Locale map (defaults to LOCALES)
+ * @returns {{ prefix: string, lang: string }}
+ */
+export function getLocale(locales = LOCALES) {
+  const { pathname } = window.location;
+  const matches = Object.keys(locales).filter(
+    (prefix) => prefix !== '' && pathname.startsWith(`${prefix}/`),
+  );
+  const prefix = matches.sort((a, b) => b.length - a.length)[0] || '';
+  const locale = locales[prefix] || locales[''];
+
+  console.log('Locale: %s', JSON.stringify(locale));
+
+  document.documentElement.lang = locale?.lang || 'en';
+  return { prefix, ...locale };
+}
+
+/**
  * Page metadata `gated=true` — same signal as CDN worker HTML gating; author preview uses this too.
  * @returns {boolean}
  */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -367,7 +367,15 @@ main ol ol {
 
 code,
 pre {
+  font-family: var(--font-family-mono);
   font-size: var(--body-font-size-s);
+}
+
+:not(pre) > code {
+  padding: 0.1em 0.35em;
+  background: rgb(161 79 43 / 10%);
+  border-radius: 4px;
+  color: var(--color-rust);
 }
 
 pre {

--- a/tools/demo/demo.css
+++ b/tools/demo/demo.css
@@ -652,6 +652,15 @@ button:disabled {
   font-size: 0.85em;
 }
 
+.slide-card code {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.875em;
+  padding: 0.1em 0.35em;
+  background: var(--accent-soft);
+  border-radius: 4px;
+  color: var(--color-rust);
+}
+
 /* ——— Breakpoints (600 / 900 / 1200) ——— */
 @media (width <= 900px) {
   .presenter-shell {

--- a/tools/demo/demo.js
+++ b/tools/demo/demo.js
@@ -209,6 +209,11 @@ function escapeHtml(value) {
     .replaceAll("'", '&#39;');
 }
 
+/** Escape HTML then render `backtick` spans as inline <code> elements. */
+function formatText(value) {
+  return escapeHtml(value).replace(/`([^`\n]+)`/g, '<code>$1</code>');
+}
+
 function normalizeExternalUrl(value) {
   const trimmed = String(value || '').trim();
   if (!trimmed) return '';
@@ -324,11 +329,11 @@ function renderSlide(slide) {
         <h2 class="slide-title">${escapeHtml(slide.title || 'Slide')}</h2>
       </header>
 
-      ${slide.lead ? `<p class="slide-lead">${escapeHtml(slide.lead)}</p>` : ''}
+      ${slide.lead ? `<p class="slide-lead">${formatText(slide.lead)}</p>` : ''}
 
       ${bullets.length ? `
         <ul class="slide-list">
-          ${bullets.map((b) => `<li>${escapeHtml(b)}</li>`).join('')}
+          ${bullets.map((b) => `<li>${formatText(b)}</li>`).join('')}
         </ul>
       ` : ''}
 
@@ -342,7 +347,7 @@ function renderSlide(slide) {
       ${slide.takeaway ? `
         <aside class="slide-takeaway" aria-label="Key takeaway">
           <span class="takeaway-label">Key takeaway</span>
-          <p class="takeaway-text">${escapeHtml(slide.takeaway)}</p>
+          <p class="takeaway-text">${formatText(slide.takeaway)}</p>
         </aside>
       ` : ''}
 


### PR DESCRIPTION
## Summary

- Adds locale-aware fragment loading: on `/de/page`, a fragment at `/fragments/nav` first tries `/de/fragments/nav`, then falls back to `/fragments/nav` if not found
- Adds `#_dnt` (do not translate) hash support — appending `#_dnt` to any fragment URL skips localization for that fragment
- Sets `<html lang>` automatically from the detected URL locale on every page load
- Adds inline `code` font style to the demo presenter tool, with backtick-to-`<code>` rendering in slide content

## Changes

| File | What changed |
|---|---|
| `scripts/shared.js` | Added `LOCALES` config map and `getLocale()` — detects locale from URL, sets `document.documentElement.lang` |
| `scripts/scripts.js` | Calls `getLocale()` in `loadEager` (replaces hardcoded `lang="en"`); passes `pathname + hash` to `loadFragment` so `#_dnt` survives the `new URL()` parse |
| `blocks/fragment/fragment.js` | Locale-prefixed fetch with fallback; strips `#_dnt` and skips localization when present |
| `tools/demo/demo.css` | `.slide-card code` style using JetBrains Mono with rust-tinted pill |
| `tools/demo/demo.js` | `formatText()` helper converts backtick spans to `<code>` elements in lead, bullets, and takeaway |

## Test URLs

- **Preview (English root):** https://feature-fragment-locale--demo--scdemos.aem.page/
- **Preview (German):** https://feature-fragment-locale--demo--scdemos.aem.page/de

## Pattern reference

Mirrors the locale-aware approach in [aemsites/author-kit](https://github.com/aemsites/author-kit) (`decorateHash` / `localizeUrl`), adapted to the aem-boilerplate fragment loading pipeline.

Fixes #25 

🤖 Generated with [Claude Code](https://claude.com/claude-code)