### PR TITLE
feat: add llms.txt files and CDN rewrite for demo2.bbird.live 

### DIFF
--- a/llms-demo.txt
+++ b/llms-demo.txt
@@ -1,0 +1,51 @@
+# diyFIRE
+
+> An educational platform for the FIRE (Financial Independence, Retire Early) movement, helping Canadians achieve financial independence through disciplined saving, intentional spending, and long-term investing.
+
+diyFIRE offers a rich content library, interactive tools, guided learning journeys, live events, and curated products for every stage of the financial independence journey. The platform's core belief: financial literacy remains one of the most overlooked skills in modern life, and the goal of FIRE is the freedom to pursue work and interests without financial pressure.
+
+## Getting Started
+
+- [Home](https://demo.bbird.live/): Platform overview and the diyFIRE philosophy
+- [Start Here](https://demo.bbird.live/start-here): 5-minute quiz generating a personalized FIRE plan
+- [New to Investing](https://demo.bbird.live/new-to-investing): Foundational resources for beginners
+- [Already Investing](https://demo.bbird.live/already-investing): Advanced content for those further along the path
+- [Guided Journey](https://demo.bbird.live/guided-journey): Structured, step-by-step learning path through financial independence
+- [About Us](https://demo.bbird.live/about-us): Team background and mission
+
+## Learn
+
+- [Learn Hub](https://demo.bbird.live/learn): Full content library organized by topic
+- [FIRE](https://demo.bbird.live/learn/fire): What FIRE is, its flavours, and how to pursue it
+- [TFSA](https://demo.bbird.live/learn/tfsa): Tax-Free Savings Account — rules, contribution room, and strategy
+- [RRSP](https://demo.bbird.live/learn/rrsp): Registered Retirement Savings Plan — deductions, withdrawals, and optimal use
+- [FHSA](https://demo.bbird.live/learn/fhsa): First Home Savings Account — Canada's newest registered account
+- [RESP](https://demo.bbird.live/learn/resp): Registered Education Savings Plan — saving for a child's education
+- [Investing](https://demo.bbird.live/learn/investing): ETFs, stocks, bonds, and investment strategy fundamentals
+- [Retirement](https://demo.bbird.live/learn/retirement): Retirement planning including CPP, OAS, and GIS
+- [Unregistered Accounts](https://demo.bbird.live/learn/unregistered-cash): Non-registered investment strategies
+- [TFSA vs RRSP vs FHSA](https://demo.bbird.live/learn/accounts/tfsa-vs-rrsp-vs-fhsa): Side-by-side account comparison guide
+
+## Articles
+
+- [Articles](https://demo.bbird.live/articles): Latest articles on personal finance, investing, and FIRE
+
+## Events
+
+- [Events](https://demo.bbird.live/events): Workshops, webinars, and community events
+
+## Tools & Calculators
+
+- [Savings Rate Calculator](https://demo.bbird.live/tools/savings-rate): Calculate and optimize your savings rate toward FIRE
+- [Compound Interest Calculator](https://demo.bbird.live/tools/compound-interest-calculator): Project investment growth over time
+- [Net Worth Tracker](https://demo.bbird.live/tools/net-worth): Track and visualize your net worth progress
+
+## Products
+
+- [Books](https://demo.bbird.live/products/books): Curated personal finance reading list
+- [Courses](https://demo.bbird.live/products/courses): Structured learning programs
+- [Tools](https://demo.bbird.live/products/tools): Premium financial planning tools
+
+## FAQs
+
+- [FAQs](https://demo.bbird.live/faqs): Frequently asked questions about FIRE and investing

--- a/llms-demo.txt
+++ b/llms-demo.txt
@@ -1,4 +1,4 @@
-# diyFIRE
+# FIRE
 
 > An educational platform for the FIRE (Financial Independence, Retire Early) movement, helping Canadians achieve financial independence through disciplined saving, intentional spending, and long-term investing.
 

--- a/llms-demo2.txt
+++ b/llms-demo2.txt
@@ -1,4 +1,4 @@
-# diyFIRE
+# FIRE
 
 > An educational platform for the FIRE (Financial Independence, Retire Early) movement, helping Canadians build wealth through disciplined saving, intentional spending, and long-term investing.
 

--- a/llms-demo2.txt
+++ b/llms-demo2.txt
@@ -1,0 +1,43 @@
+# diyFIRE
+
+> An educational platform for the FIRE (Financial Independence, Retire Early) movement, helping Canadians build wealth through disciplined saving, intentional spending, and long-term investing.
+
+diyFIRE provides interactive tools, guided learning paths, and a comprehensive content library covering Canadian registered accounts, investment strategies, and personal finance fundamentals. The core philosophy: financial independence is less about retiring early and more about gaining the freedom to pursue meaningful work without financial pressure.
+
+## Getting Started
+
+- [Home](https://demo2.bbird.live/): Platform overview and the diyFIRE philosophy
+- [Start Here](https://demo2.bbird.live/start-here): 5-minute quiz that generates a personalized FIRE plan
+- [New to Investing](https://demo2.bbird.live/new-to-investing): Foundational guide for those beginning their financial independence journey
+- [Already Investing](https://demo2.bbird.live/already-investing): Resources for those further along the path
+- [Guided Journey](https://demo2.bbird.live/guided-journey): Structured, step-by-step learning path
+- [About Us](https://demo2.bbird.live/about-us): Team background and mission
+
+## Learn
+
+- [Learn Hub](https://demo2.bbird.live/learn): Full content library organized by topic
+- [FIRE](https://demo2.bbird.live/learn/fire): What FIRE is, its flavours, and how to pursue it
+- [TFSA](https://demo2.bbird.live/learn/tfsa): Tax-Free Savings Account — rules, contribution room, and strategy
+- [RRSP](https://demo2.bbird.live/learn/rrsp): Registered Retirement Savings Plan — deductions, withdrawals, and optimal use
+- [FHSA](https://demo2.bbird.live/learn/fhsa): First Home Savings Account — Canada's newest registered account
+- [RESP](https://demo2.bbird.live/learn/resp): Registered Education Savings Plan — saving for a child's education
+- [Investing](https://demo2.bbird.live/learn/investing): ETFs, stocks, bonds, and investment strategy fundamentals
+- [Retirement](https://demo2.bbird.live/learn/retirement): Retirement planning including CPP, OAS, and GIS
+- [Unregistered Accounts](https://demo2.bbird.live/learn/unregistered-cash): Non-registered investment strategies
+- [TFSA vs RRSP vs FHSA](https://demo2.bbird.live/learn/accounts/tfsa-vs-rrsp-vs-fhsa): Side-by-side account comparison guide
+
+## Tools & Calculators
+
+- [Savings Rate Calculator](https://demo2.bbird.live/tools/savings-rate): Calculate and optimize your savings rate toward FIRE
+- [Compound Interest Calculator](https://demo2.bbird.live/tools/compound-interest-calculator): Project investment growth over time
+- [Net Worth Tracker](https://demo2.bbird.live/tools/net-worth): Track and visualize your net worth progress
+
+## Products
+
+- [Books](https://demo2.bbird.live/products/books): Curated personal finance reading list
+- [Courses](https://demo2.bbird.live/products/courses): Structured learning programs
+- [Tools](https://demo2.bbird.live/products/tools): Premium financial planning tools
+
+## FAQs
+
+- [FAQs](https://demo2.bbird.live/faqs): Frequently asked questions about FIRE and investing

--- a/workers/adobe/config/cdn.yaml
+++ b/workers/adobe/config/cdn.yaml
@@ -1,6 +1,21 @@
 kind: "CDN"
 version: "1"
 data:
+  requestTransformations:
+    rules:
+      - name: rewrite-demo2-llms-txt
+        when:
+          allOf:
+            - reqProperty: domain
+              matches: '^(www\.)?demo2\.bbird\.live$'
+            - reqProperty: path
+              equals: /llms.txt
+        actions:
+          - type: transform
+            op: replace
+            reqProperty: path
+            match: '^/llms\.txt$'
+            replacement: '/llms-demo2.txt'
   trafficFilters:
     rules:
       - name: block-demo2-path


### PR DESCRIPTION
Adds llms-demo.txt and llms-demo2.txt with structured content following
the llms.txt spec, and a CDN requestTransformation to serve /llms.txt
transparently from /llms-demo2.txt on demo2.bbird.live.
Fix #<gh-issue-id>

Test URLs:
- Before: https://main--demo--scdemos.aem.live/
- After: https://llms-txt--demo--scdemos.aem.live/
