### PR TITLE
chore: fix code block styling, allow copy

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -175,6 +175,65 @@ export function decorateMain(main) {
   if (document.contains(main)) initPageSchemas();
 }
 
+/**
+ * Add a "copy" button to every <pre><code> block in `main`. The EDS html
+ * pipeline renders fenced code blocks as <pre><code>…</code></pre>, so this
+ * works for any authored code snippet across the site.
+ *
+ * Idempotent: skips blocks that have already been decorated.
+ */
+function decorateCodeBlocks(main) {
+  if (!main || !navigator.clipboard) return;
+  const blocks = main.querySelectorAll('pre:has(> code)');
+  blocks.forEach((pre) => {
+    if (pre.parentElement?.classList.contains('code-block')) return;
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'code-block';
+    pre.replaceWith(wrapper);
+    wrapper.append(pre);
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'code-block-copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.innerHTML = `
+      <span class="code-block-copy-icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="9" y="9" width="11" height="11" rx="2"/>
+          <path d="M5 15V5a2 2 0 0 1 2-2h10"/>
+        </svg>
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="5 13 10 18 19 7"/>
+        </svg>
+      </span>
+      <span class="code-block-copy-label">Copy</span>
+    `;
+    wrapper.append(button);
+
+    let resetTimer = null;
+    button.addEventListener('click', async () => {
+      const code = pre.querySelector('code');
+      if (!code) return;
+      try {
+        await navigator.clipboard.writeText(code.textContent || '');
+        button.classList.add('is-copied');
+        button.querySelector('.code-block-copy-label').textContent = 'Copied';
+        button.setAttribute('aria-label', 'Code copied to clipboard');
+        clearTimeout(resetTimer);
+        resetTimer = setTimeout(() => {
+          button.classList.remove('is-copied');
+          button.querySelector('.code-block-copy-label').textContent = 'Copy';
+          button.setAttribute('aria-label', 'Copy code to clipboard');
+        }, 2000);
+      } catch (e) {
+        // Clipboard access can be blocked (insecure context, permission denied).
+        // Silently no-op — the button just doesn't update.
+      }
+    });
+  });
+}
+
 async function loadTemplate(main, template) {
   try {
     if (template) {
@@ -268,6 +327,7 @@ async function loadLazy(doc) {
   }
   await dynamicBlocks(main);
   applyContentProtection();
+  decorateCodeBlocks(main);
 
   const { hash } = window.location;
   const element = hash ? doc.getElementById(hash.substring(1)) : false;

--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -171,3 +171,125 @@ header .nav-wrapper.scrolled {
   outline-offset: 3px;
   border-radius: 2px;
 }
+
+.code-block {
+  position: relative;
+}
+
+.code-block > pre {
+  padding-right: calc(var(--space-l) + 90px);
+  background-color: light-dark(
+    color-mix(in srgb, var(--text-color, #1a1a2e) 8%, var(--light-color, #fff)),
+    var(--light-color, #1c1c2c)
+  );
+  border: 1px solid light-dark(
+    color-mix(in srgb, var(--text-color, #1a1a2e) 14%, transparent),
+    rgb(255 255 255 / 8%)
+  );
+  color: light-dark(var(--color-ink, #1a1a2e), var(--color-parchment, #f6f1e7));
+}
+
+.code-block > pre code {
+  color: inherit;
+  background: transparent;
+}
+
+:is(main, article.article-body) :not(pre) > code {
+  display: inline;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  background: light-dark(
+    color-mix(in srgb, var(--text-color, #1a1a2e) 8%, transparent),
+    rgb(255 255 255 / 10%)
+  );
+  color: var(--color-rust);
+  -webkit-text-fill-color: currentcolor;
+  font-size: 0.9em;
+  font-weight: 600;
+  white-space: nowrap;
+  word-break: keep-all;
+}
+
+:is(main, article.article-body) a:any-link > code {
+  color: inherit;
+}
+
+.code-block-copy {
+  position: absolute;
+  top: var(--space-s, 12px);
+  right: var(--space-s, 12px);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border: 1px solid light-dark(rgb(0 0 0 / 10%), rgb(255 255 255 / 15%));
+  border-radius: 6px;
+  background: light-dark(rgb(255 255 255 / 70%), rgb(0 0 0 / 30%));
+  backdrop-filter: blur(6px);
+  color: light-dark(var(--color-ink, #111), var(--color-parchment, #fff));
+  -webkit-text-fill-color: currentcolor;
+  font-family: var(--body-font-family);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.55;
+  transition: opacity 0.18s ease, background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+}
+
+.code-block-copy:focus-visible {
+  opacity: 1;
+}
+
+.code-block-copy:hover {
+  opacity: 1;
+  background: light-dark(rgb(255 255 255 / 95%), rgb(0 0 0 / 55%));
+  border-color: light-dark(rgb(0 0 0 / 18%), rgb(255 255 255 / 25%));
+}
+
+.code-block:hover .code-block-copy {
+  opacity: 1;
+}
+
+.code-block-copy-icon {
+  display: inline-grid;
+  width: 16px;
+  height: 16px;
+}
+
+.code-block-copy-icon > svg {
+  grid-area: 1 / 1;
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.code-block-copy-icon > svg:first-child {
+  opacity: 1;
+}
+
+.code-block-copy-icon > svg:last-child {
+  opacity: 0;
+  transform: scale(0.6);
+}
+
+.code-block-copy.is-copied {
+  color: light-dark(var(--color-green-500), var(--color-green-400));
+  border-color: currentcolor;
+  opacity: 1;
+}
+
+.code-block-copy.is-copied .code-block-copy-icon > svg:first-child {
+  opacity: 0;
+  transform: scale(0.6);
+}
+
+.code-block-copy.is-copied .code-block-copy-icon > svg:last-child {
+  opacity: 1;
+  transform: scale(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .code-block-copy,
+  .code-block-copy-icon > svg {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Allows copying code blocks and snippets, useful for things like the exmod prompt and other configuration code snippets in the documentation.

Test URLs:
- Before: https://main--demo--scdemos.aem.live/demo-docs/usecases/how-to-reskin-using-xmod
- After: https://codeblocks--demo--scdemos.aem.live/demo-docs/usecases/how-to-reskin-using-xmod
