### PR TITLE
feat(martech): data-mbox auto-discovery for Target/AJO propositions

### DIFF
--- a/plugins/martech/README.md
+++ b/plugins/martech/README.md
@@ -185,10 +185,11 @@ async function loadEager(doc) {
     {
       personalization: !!getMetadata('target') && isConsentGiven,
       launchUrls: [/* your Launch script URLs here */],
-      // For Form-Based activities at named mboxes, add the scope(s) here.
-      // decisionScopes: ['target-global-mbox'],
-      // If those offers don't embed a CSS selector, add a fallback map.
-      // propositionMetadata: { 'target-global-mbox': { selector: 'main h2', actionType: 'replaceHtml' } },
+      // To request additional decision scopes beyond the default `__view__` scope,
+      // list them here. They are added to the eager personalization fetch.
+      // decisionScopes: ['my-scope-name'],
+      // Form-Based HTML offers are targeted via `mbox` section metadata (auto-discovered as
+      // `data-mbox`) — see "Working with Form-Based Activities" below.
       // See the API Reference for all available options.
     },
   );
@@ -256,10 +257,11 @@ Initializes the library. This should be called once in `loadEager`.
   - `personalization` `{Boolean}`: Enable personalization. Default: `true`.
   - `performanceOptimized` `{Boolean}`: Use aggressive performance optimizations. Default: `true`.
   - `personalizationTimeout` `{Number}`: Timeout in ms for personalization. Default: `1000`.
-  - `trackPageView` `{Boolean}`: Whether to automatically send a page view event on page activation. When `false`, the library sends a `decisioning.propositionDisplay` event instead, so proposition display is still reported to Target without triggering an extra page view. Set to `false` if this is already handled separately in the page. Default: `true`.
+  - `trackPageView` `{Boolean}`: Whether to automatically send a page view event on page activation. Proposition display is reported independently via `decisioning.propositionDisplay` as each offer renders, so setting this to `false` (e.g. when page views are handled separately) still reports impressions to Target without an extra page view. Default: `true`.
   - `shouldProcessEvent` `{Function}`: A function that receives a data layer event payload and returns `false` to prevent it from being sent.
-  - `decisionScopes` `{String[]}`: Additional decision scopes to request beyond the default `__view__` scope. Required for Form-Based activities targeting named mboxes (e.g. `['target-global-mbox']`). Default: `[]`.
-  - `propositionMetadata` `{Object}`: Selector fallback map for Form-Based HTML offers that do not carry a built-in CSS selector (e.g. raw HTML offers created manually in Target). Keys are decision scope names; values are `{ selector, actionType }` objects where `actionType` is `'setHtml'`, `'replaceHtml'` (default), or `'appendHtml'`. DA "Send to Target" offers embed their own selector and do not need an entry here. Default: `{}`.
+  - `decisionScopes` `{String[]}`: Additional decision scopes to request beyond the default `__view__` scope. Previously this required mutating the payload via `onBeforeEventSend`; this provides a dedicated config field. The scopes are included in both the eager `propositionFetch` (when `performanceOptimized` is `true`) and the `martechLazy` `sendEvent` (when `performanceOptimized` is `false`), with `__view__` always included. Default: `[]`.
+  - `propositionScopeAttribute` `{String|null}`: The `data-*` attribute the plugin scans to auto-discover decision scopes from the DOM (rendered from `mbox` section metadata). Comma-separated values declare multiple scopes per element. Set to `null` to disable auto-discovery. Auto-discovery only runs in the performance-optimized eager path (the default); when `performanceOptimized` is `false`, request scopes explicitly via `decisionScopes`. Default: `'mbox'`.
+  - `discoveredScopeActionType` `{String}`: Default `actionType` for auto-discovered scopes when neither the offer nor the section's `data-mbox-action` specifies one. One of `'setHtml'`, `'replaceHtml'`, `'appendHtml'`. Default: `'setHtml'`.
 
 ---
 
@@ -349,47 +351,80 @@ window.addEventListener('consent.onetrust', consentEventHandler);
 
 ## Working with Form-Based Activities
 
-Adobe Target Form-Based activities (offers created in the Target UI rather than the Visual Experience Composer) require two additional configuration steps because the Web SDK does not fetch named mbox propositions by default.
+Form-Based HTML offers in Adobe Target deliver an `html-content-item` proposition that
+doesn't carry a CSS selector in the offer payload. The plugin needs to know where to put
+the HTML. The recommended way to wire this up in EDS is **author-controlled section
+metadata** — authors tag sections in DA with `mbox` rows, the Helix HTML pipeline
+pre-renders these as `data-mbox` attributes on the section element, and the plugin
+discovers them automatically at the start of `martechEager`.
 
-### Step 1 — Request the mbox scope
+### Authoring contract
 
-Add the mbox name(s) to `decisionScopes` in your `initMartech` call:
+In DA, add a `section-metadata` block to any section you want to personalize:
+
+| section metadata | |
+|---|---|
+| mbox | hero-offer |
+
+Multiple mboxes per section (comma-separated):
+
+| section metadata | |
+|---|---|
+| mbox | hero-offer, audience-banner |
+
+Optional per-section actionType override (default is `setHtml`, which preserves the
+section element and its decoration state — see "Why `setHtml`" below):
+
+| section metadata | |
+|---|---|
+| mbox | hero-offer |
+| mbox-action | replaceHtml |
+
+Valid `mbox-action` values: `setHtml`, `replaceHtml`, `appendHtml`. Invalid values fall
+back to the default with a debug warning.
+
+### What the plugin does
+
+For each `[data-mbox]` element it discovers:
+
+1. Splits the attribute value on `,` to get individual mbox names.
+2. Sanitizes each name for CSS identifier safety: `name.replace(/[^a-zA-Z0-9_-]/g, '-')`.
+3. Adds a synthetic class `martech-mbox-{sanitized-name}` to the element (idempotent).
+4. Registers `{ selector: '.martech-mbox-{sanitized-name}', actionType }` for the scope in
+   an internal map used to place `html-content-item` offers. An offer that embeds its own
+   selector still wins over the synthetic one.
+5. Adds the unsanitized mbox name to `config.decisionScopes` (de-duplicated).
+6. Marks the element with `martech-mbox-scanned` so subsequent per-tick re-scans skip it.
+
+The plugin's existing `MutationObserver` (which runs `applyPropositions` on every section /
+block decoration tick) re-runs the same scan, so mboxes introduced by fragments, dynamic
+blocks, or Universal Editor edits also get picked up. Scopes that arrive *after* the eager
+`propositionFetch` are logged with a debug warning — they won't be personalized on this
+page load (v1 limitation; the eager fetch is single-shot).
+
+### Why `setHtml` is the default
+
+`setHtml` replaces the *children* of the target element — preserving the element itself,
+its `class="section"`, `data-section-status="loaded"`, scroll-reveal state, and the
+`data-mbox` attribute (so a second offer for the same scope can still target it).
+`replaceHtml` swaps the element out entirely; useful when an offer is authored as a
+whole section but easy to misuse (it removes EDS decoration markers that downstream code
+may rely on). Choose `replaceHtml` per-section when you know the offer is shaped like
+the section it replaces.
+
+### Configuration
 
 ```js
 initMartech(webSDKConfig, {
   personalization: true,
-  decisionScopes: ['target-global-mbox'],
+  // Default values shown — adjust to taste:
+  propositionScopeAttribute: 'mbox',       // set to null to disable auto-discovery
+  discoveredScopeActionType: 'setHtml',    // default for discovered scopes
 });
 ```
 
-Without this, the Web SDK only fetches `__view__` (VEC) propositions and Form-Based activities at named mboxes are silently ignored.
-
-### Step 2 — Provide a selector fallback (if needed)
-
-Offers sent from **Document Authoring via "Send to Target"** embed their own CSS selector in the offer data — no further configuration is required for those.
-
-For **raw HTML offers** created manually in the Target UI (which have no built-in selector), provide a `propositionMetadata` fallback map:
-
-```js
-initMartech(webSDKConfig, {
-  personalization: true,
-  decisionScopes: ['target-global-mbox'],
-  propositionMetadata: {
-    'target-global-mbox': {
-      // CSS selector of the element the offer content targets
-      selector: 'main .hero',
-      // 'setHtml'     — replace the inner HTML of the matched element (preserves the element)
-      // 'replaceHtml' — replace the matched element itself with the offer content (default)
-      // 'appendHtml'  — append the offer content as children of the matched element
-      actionType: 'setHtml',
-    },
-  },
-});
-```
-
-The same `propositionMetadata` field also acts as a **rescue override for misconfigured VEC offers**: if a dom-action item arrives with a non-visual selector (`head`, `body`, or `html`) — which can happen when a DA offer is re-sent without updating its selector — the plugin reroutes it through the matching `propositionMetadata` entry and applies it directly. Items with no override (or whose override selector is itself `head`/`body`/`html`) are dropped with a debug-mode warning to prevent unintended document-chrome mutations.
-
-> **Reporting note:** When the rescue override path is used, the plugin manually fires a `decisioning.propositionDisplay` event so Target Activity reporting still records an impression for the delivered offer.
+See [`docs/form-based-target-activities.md`](https://github.com/adobe-rnd/aem-martech/blob/main/docs/form-based-target-activities.md)
+for a focused, author-facing walkthrough of using Form-Based activities.
 
 ## Working with Dynamic Content (SPAs)
 

--- a/plugins/martech/src/index.js
+++ b/plugins/martech/src/index.js
@@ -33,26 +33,34 @@
  *                                         and returns a boolean. Return true to process the event,
  *                                         false to ignore it. The default is a function that
  *                                         always returns true.
- * @property {Object} [propositionMetadata] Selector mapping for Form-Based HTML offers that do
- *                                          not carry a built-in CSS selector (e.g. raw HTML offers
- *                                          created manually in Target). Keys are decision scope
- *                                          names; values are `{ selector, actionType }` objects
- *                                          where actionType is 'setHtml', 'replaceHtml', or
- *                                          'appendHtml' (defaults to 'replaceHtml'). Offers sent
- *                                          from DA via "Send to Target" carry their own selector
- *                                          and do not need an entry here.
- *                                          Example: `{ 'target-global-mbox': { selector: 'main h2',
- *                                          actionType: 'replaceHtml' } }`
- * @property {String[]} [decisionScopes]    Additional decision scopes to request beyond the default
- *                                          __view__ scope. Required for Form-Based activities at
- *                                          named mboxes (e.g. ['target-global-mbox']).
- *                                          (defaults to [])
+ * @property {String[]} [decisionScopes]   Additional decision scopes to request beyond the
+ *                                         default `__view__` scope. The scopes are included
+ *                                         in both the eager `propositionFetch` (performance
+ *                                         path) and the `martechLazy` `sendEvent`
+ *                                         (non-performance path), with `__view__` always
+ *                                         included.
+ *                                         (defaults to [])
+ * @property {String|null} propositionScopeAttribute The `data-*` attribute name the plugin
+ *                                          scans for to auto-discover decision scopes from
+ *                                          the DOM. Multiple scopes per element supported
+ *                                          via comma-separated values. Set to `null` to
+ *                                          disable auto-discovery. Auto-discovery only runs in
+ *                                          the performance-optimized eager path (the default);
+ *                                          when `performanceOptimized` is false, request scopes
+ *                                          explicitly via `decisionScopes`. (defaults to "mbox")
+ * @property {String} discoveredScopeActionType The default `actionType` for auto-discovered
+ *                                          scopes when neither the offer nor the section's
+ *                                          `data-mbox-action` attribute specifies one.
+ *                                          Valid values: 'setHtml', 'replaceHtml',
+ *                                          'appendHtml'. (defaults to "setHtml")
  */
 const SCHEMA_DOM_ACTION = 'https://ns.adobe.com/personalization/dom-action';
 const SCHEMA_HTML_CONTENT_ITEM = 'https://ns.adobe.com/personalization/html-content-item';
 // Selectors that target the document chrome rather than visible content. If a dom-action item
 // arrives with one of these, alloy's applyPropositions injects directly into <head>/<body>/<html>.
 const NON_VISUAL_SELECTORS = new Set(['head', 'body', 'html']);
+// Action types the plugin understands for applying an offer to its target element.
+const VALID_ACTION_TYPES = new Set(['setHtml', 'replaceHtml', 'appendHtml']);
 
 export const DEFAULT_CONFIG = {
   analytics: true,
@@ -66,8 +74,9 @@ export const DEFAULT_CONFIG = {
   performanceOptimized: true,
   personalizationTimeout: 1000,
   shouldProcessEvent: () => true,
-  propositionMetadata: {},
   decisionScopes: [],
+  propositionScopeAttribute: 'mbox',
+  discoveredScopeActionType: 'setHtml',
 };
 
 let config;
@@ -75,6 +84,16 @@ let alloyConfig;
 let isAlloyConfigured = false;
 const pendingAlloyCommands = [];
 const pendingDatalayerEvents = [];
+/** IDs of propositions that have been actually displayed (direct-inject or alloy-applied). */
+const renderedPropositionIds = new Set();
+/** IDs of propositions that have already been reported via a manual sendEvent call. */
+const reportedPropositionIds = new Set();
+/**
+ * Scope -> { selector, actionType } map for Form-Based html-content-item offers, built only by
+ * `data-mbox` auto-discovery (see discoverPropositionScopes). Internal — there is no consumer
+ * config for hand-mapping scopes to selectors; authors declare targets via section metadata.
+ */
+const discoveredScopeMeta = new Map();
 
 const debug = (label = 'martech', ...args) => {
   if (alloyConfig?.debugEnabled) {
@@ -82,6 +101,39 @@ const debug = (label = 'martech', ...args) => {
     console.debug.call(null, `[${label}]`, ...args);
   }
 };
+
+/**
+ * Decides whether a selector is safe to hand to alloy or to a direct-injection target
+ * lookup. Rejects empty/non-string values, document-chrome selectors (head/body/html,
+ * case- and whitespace-insensitive), and syntactically-invalid CSS. Debug-logs the
+ * reason on every rejection, prefixed with the supplied context label for traceability.
+ *
+ * @param {String} rawSelector The raw selector — from `item.data.selector`, from the
+ *                              auto-discovered `data-mbox` synthetic selector, or any
+ *                              other untrusted source.
+ * @param {String} contextLabel Free-form short label like `html-content-item scope "foo"`.
+ *                              Surfaced in debug logs.
+ * @returns {Boolean} true if the selector is non-empty, visual, and parseable; false
+ *                    otherwise.
+ */
+function isVisualSelector(rawSelector, contextLabel) {
+  if (!rawSelector || typeof rawSelector !== 'string') {
+    debug('martech', `dropping ${contextLabel}: selector is empty or non-string`);
+    return false;
+  }
+  const normalized = rawSelector.trim().toLowerCase();
+  if (NON_VISUAL_SELECTORS.has(normalized)) {
+    debug('martech', `dropping ${contextLabel}: non-visual selector "${rawSelector}"`);
+    return false;
+  }
+  try {
+    document.querySelector(rawSelector);
+  } catch (err) {
+    debug('martech', `dropping ${contextLabel}: invalid CSS — "${rawSelector}" (${err.message})`);
+    return false;
+  }
+  return true;
+}
 
 /**
  * Triggers the callback when the page is actually activated,
@@ -410,54 +462,107 @@ let response;
 /**
  * Resolves the target selector and actionType for a Form-Based html-content-item.
  * Priority: selector embedded in item data (DA "Send to Target" offers carry this automatically)
- * > propositionMetadata config fallback (manually created raw HTML offers).
+ * > the synthetic selector auto-discovered from the section's `data-mbox` attribute.
  * @returns {{selector: String, actionType: String}|null} null when no selector can be resolved
  */
 function resolveHtmlContentTarget(item, scope) {
-  const selector = item.data?.selector || config.propositionMetadata?.[scope]?.selector;
-  if (!selector) return null;
-  const actionType = item.data?.actionType
-    || config.propositionMetadata?.[scope]?.actionType
-    || 'replaceHtml';
+  const embedded = item?.data?.selector;
+  const discovered = discoveredScopeMeta.get(scope);
+  const selector = embedded || discovered?.selector;
+  if (!isVisualSelector(selector, `html-content-item scope "${scope}"`)) {
+    return null;
+  }
+  const actionType = item?.data?.actionType
+    || discovered?.actionType
+    || 'setHtml';
   return { selector, actionType };
 }
 
-/**
- * Applies an HTML offer's content to a target element using alloy's actionType vocabulary.
- * Mirrors what alloy itself does for setHtml/replaceHtml/appendHtml so the direct-injection
- * fallback behaves identically to the alloy-handled path.
- */
-function applyHtmlAction(target, content, actionType) {
-  const parser = new DOMParser();
-  const parsed = parser.parseFromString(content, 'text/html');
-  const nodes = [...parsed.body.childNodes];
-  if (actionType === 'appendHtml') {
-    target.append(...nodes);
-  } else if (actionType === 'setHtml') {
-    target.replaceChildren(...nodes);
-  } else {
-    // replaceHtml (alloy semantics: replace the element itself)
-    target.replaceWith(...nodes);
-  }
-}
+// Marker class added to every element we've already processed. The :not(.martech-mbox-scanned)
+// filter on the discovery selector makes the per-tick re-scan O(new-elements), not O(all-mboxes).
+const SCANNED_MARKER = 'martech-mbox-scanned';
 
-// Cap retries for direct-inject entries so a typo'd or never-rendering selector can't
-// keep generating querySelector calls for the life of the page.
-const DIRECT_INJECT_MAX_ATTEMPTS = 20;
+/**
+ * Scans the DOM under `root` for elements carrying the configured proposition-scope
+ * attribute (default `data-mbox`) and registers a synthetic-class selector + actionType
+ * per scope into the internal `discoveredScopeMeta` map. Returns the discovered scope names
+ * so the caller can merge them into `config.decisionScopes`. Idempotent — elements marked
+ * with the SCANNED_MARKER class are skipped on subsequent calls.
+ *
+ * @param {Document|Element} root The DOM root to scan.
+ * @returns {String[]} Scope names discovered during this call only (not previously-scanned).
+ */
+function discoverPropositionScopes(root) {
+  if (!config.propositionScopeAttribute) return [];
+  const attr = config.propositionScopeAttribute;
+  const selector = `[data-${attr}]:not(.${SCANNED_MARKER})`;
+  const elements = root.querySelectorAll(selector);
+  const newScopes = [];
+  elements.forEach((el) => {
+    const raw = el.getAttribute(`data-${attr}`);
+    if (!raw) {
+      el.classList.add(SCANNED_MARKER);
+      return;
+    }
+    const scopes = raw.split(',').map((s) => s.trim()).filter(Boolean);
+    const elementAction = el.getAttribute(`data-${attr}-action`);
+    let actionType;
+    if (elementAction && VALID_ACTION_TYPES.has(elementAction)) {
+      actionType = elementAction;
+    } else {
+      if (elementAction) {
+        debug('martech', `ignoring invalid data-${attr}-action="${elementAction}"; valid values: setHtml, replaceHtml, appendHtml`);
+      }
+      // Fall back to the configured default, validating it too — a bad config value shouldn't
+      // be handed to alloy as an actionType.
+      const configured = config.discoveredScopeActionType;
+      if (configured && !VALID_ACTION_TYPES.has(configured)) {
+        debug('martech', `invalid discoveredScopeActionType "${configured}"; using "setHtml"`);
+      }
+      actionType = VALID_ACTION_TYPES.has(configured) ? configured : 'setHtml';
+    }
+    scopes.forEach((scope) => {
+      const sanitized = scope.replace(/[^a-zA-Z0-9_-]/g, '-');
+      if (sanitized !== scope) {
+        debug('martech', `mbox name "${scope}" sanitized to "${sanitized}" for CSS class`);
+      }
+      const scopeSelector = `.martech-mbox-${sanitized}`;
+      // Distinct raw scopes can sanitize to the same class (e.g. "a.b" and "a-b"). Warn so a
+      // silent wrong-element application is at least discoverable in debug.
+      const collision = [...discoveredScopeMeta]
+        .find(([s, m]) => s !== scope && m.selector === scopeSelector);
+      if (collision) {
+        debug('martech', `mbox "${scope}" and "${collision[0]}" both map to ${scopeSelector}; an offer for one may target the other's element`);
+      }
+      el.classList.add(`martech-mbox-${sanitized}`);
+      discoveredScopeMeta.set(scope, { selector: scopeSelector, actionType });
+      newScopes.push(scope);
+    });
+    el.classList.add(SCANNED_MARKER);
+  });
+  return newScopes;
+}
 
 /**
  * Fires a single `decisioning.propositionDisplay` event covering one or more propositions
- * we applied outside the alloy pipeline (non-visual dom-action fallback), so Target Activity
- * reporting still records an impression.
+ * alloy has rendered, so Target Activity reporting records an impression. Idempotent per
+ * proposition id for the life of the page.
  */
 function reportPropositionDisplay(instanceName, propositions) {
-  if (!propositions.length) return;
+  // Idempotent: each proposition is reported at most once for the life of the page, so this is
+  // safe to call per decoration tick (and from deferred page-activation callbacks).
+  const toReport = (propositions || []).filter((p) => p && !reportedPropositionIds.has(p.id));
+  if (!toReport.length) return;
+  toReport.forEach((p) => {
+    renderedPropositionIds.add(p.id);
+    reportedPropositionIds.add(p.id);
+  });
   window[instanceName]('sendEvent', {
     xdm: {
       eventType: 'decisioning.propositionDisplay',
       _experience: {
         decisioning: {
-          propositions: propositions.map((p) => ({
+          propositions: toReport.map((p) => ({
             id: p.id,
             scope: p.scope,
             scopeDetails: p.scopeDetails,
@@ -478,6 +583,14 @@ function reportPropositionDisplay(instanceName, propositions) {
  * @returns a promise that the propositions were retrieved and will be applied as the page renders
  */
 async function applyPropositions(instanceName) {
+  const discoveredScopes = discoverPropositionScopes(document);
+  if (discoveredScopes.length) {
+    debug('martech', `auto-discovered ${discoveredScopes.length} scope(s):`, discoveredScopes);
+    config.decisionScopes = [
+      ...new Set([...(config.decisionScopes || []), ...discoveredScopes]),
+    ];
+  }
+
   // Get the decisions, but don't render them automatically
   // so we can hook up into the AEM EDS page load sequence
   const renderDecisionResponse = await sendEvent({
@@ -485,20 +598,20 @@ async function applyPropositions(instanceName) {
     renderDecisions: false,
     personalization: {
       sendDisplayEvent: false,
-      ...(config.decisionScopes?.length && { decisionScopes: config.decisionScopes }),
+      // Always request `__view__` alongside any named scopes. The Web SDK treats
+      // `decisionScopes` as the exact set to fetch, so omitting `__view__` here would silently
+      // drop all VEC / page-load (view) propositions on any page that has a discovered mbox.
+      decisionScopes: [...new Set(['__view__', ...(config.decisionScopes || [])])],
     },
   });
   response = renderDecisionResponse;
   if (!renderDecisionResponse?.propositions) {
     return [];
   }
-  // dom-action items targeting a non-visual element (head/body/html) are usually a misconfigured
-  // VEC offer — alloy would inject into <head>/<body>/<html>. Pull them out of the alloy pipeline
-  // and apply them via propositionMetadata override (or drop them) instead. Also drop
-  // html-content-item items that have no resolvable selector so they aren't retried every tick.
-  // Build the html-content-item metadata map up front so the per-tick callback doesn't have to
-  // re-walk the propositions tree.
-  let directInjectQueue = [];
+  // dom-action (VEC) items carry their own selector and are applied by alloy directly, exactly
+  // as upstream does. html-content-item (Form-Based) offers don't carry a selector, so resolve a
+  // target from the offer or from `data-mbox` auto-discovery and hand it to alloy via the metadata
+  // map; drop items with no resolvable selector so they aren't retried every tick.
   const htmlContentMetadata = {};
   let propositions = window.structuredClone(renderDecisionResponse.propositions)
     .filter((p) => p.items.some(
@@ -507,26 +620,6 @@ async function applyPropositions(instanceName) {
     .map((p) => ({
       ...p,
       items: p.items.map((item) => {
-        if (item.schema === SCHEMA_DOM_ACTION
-          && NON_VISUAL_SELECTORS.has(item.data?.selector)) {
-          const override = config.propositionMetadata?.[p.scope];
-          if (!override?.selector) {
-            debug('martech', `dropping non-visual dom-action item with no propositionMetadata override for scope "${p.scope}"`);
-            return null;
-          }
-          if (NON_VISUAL_SELECTORS.has(override.selector)) {
-            debug('martech', `ignoring propositionMetadata override for scope "${p.scope}": selector "${override.selector}" is non-visual`);
-            return null;
-          }
-          directInjectQueue.push({
-            proposition: { id: p.id, scope: p.scope, scopeDetails: p.scopeDetails },
-            content: item.data.content,
-            selector: override.selector,
-            actionType: override.actionType || 'replaceHtml',
-            attempts: 0,
-          });
-          return null;
-        }
         if (item.schema === SCHEMA_HTML_CONTENT_ITEM) {
           const target = resolveHtmlContentTarget(item, p.scope);
           if (!target) {
@@ -540,35 +633,12 @@ async function applyPropositions(instanceName) {
     }))
     .filter((p) => p.items.length > 0);
   onDecoratedElement(async () => {
-    // Direct injection for dom-action items alloy cannot place (non-visual selector override).
-    // Re-queue items whose target hasn't been decorated yet so later mutation ticks can retry,
-    // up to DIRECT_INJECT_MAX_ATTEMPTS — past that we assume the selector is wrong and drop it.
-    if (directInjectQueue.length) {
-      const pending = directInjectQueue;
-      directInjectQueue = [];
-      const justInjected = [];
-      pending.forEach((entry) => {
-        let target;
-        try {
-          target = document.querySelector(entry.selector);
-        } catch (err) {
-          debug('martech', `propositionMetadata selector "${entry.selector}" is invalid: ${err.message}`);
-          return;
-        }
-        if (!target) {
-          entry.attempts += 1;
-          if (entry.attempts >= DIRECT_INJECT_MAX_ATTEMPTS) {
-            debug('martech', `dropping direct-inject entry after ${entry.attempts} attempts — selector "${entry.selector}" never matched`);
-            return;
-          }
-          directInjectQueue.push(entry);
-          return;
-        }
-        applyHtmlAction(target, entry.content, entry.actionType);
-        justInjected.push(entry.proposition);
-      });
-      reportPropositionDisplay(instanceName, justInjected);
-    }
+    const lateScopes = discoverPropositionScopes(document);
+    lateScopes.forEach((scope) => {
+      if (!response?.propositions?.some((p) => p.scope === scope)) {
+        debug('martech', `mbox "${scope}" discovered after eager propositionFetch; not personalized this load`);
+      }
+    });
     if (!propositions.length) {
       return;
     }
@@ -580,11 +650,28 @@ async function applyPropositions(instanceName) {
       'applyPropositions',
       applyOptions,
     );
-    appliedPropositions.propositions.forEach((item) => {
-      if (item.renderAttempted) {
-        propositions = propositions.filter((p) => p.id !== item.id);
+    // Single guarded pass over the applied items: drop rendered propositions from the retry set
+    // and collect the freshly-rendered ones to report. Reporting display *here* (as alloy
+    // actually renders, across decoration ticks) rather than at page-activation avoids the race
+    // where activation fires before async decoration has applied anything.
+    const renderedNow = [];
+    appliedPropositions.propositions?.forEach((appliedItem) => {
+      if (!appliedItem.renderAttempted) return;
+      propositions = propositions.filter((p) => p.id !== appliedItem.id);
+      if (!renderedPropositionIds.has(appliedItem.id)) {
+        const original = response?.propositions?.find((p) => p.id === appliedItem.id);
+        renderedNow.push({
+          id: appliedItem.id,
+          scope: appliedItem.scope ?? original?.scope,
+          scopeDetails: appliedItem.scopeDetails ?? original?.scopeDetails,
+        });
       }
+      renderedPropositionIds.add(appliedItem.id);
     });
+    // Prerender-aware: defer the display impression until the page is actually activated.
+    if (renderedNow.length) {
+      onPageActivation(() => reportPropositionDisplay(instanceName, renderedNow));
+    }
   });
   return renderDecisionResponse;
 }
@@ -615,6 +702,9 @@ export async function initMartech(webSDKConfig, martechConfig = {}) {
     ...martechConfig,
   };
 
+  renderedPropositionIds.clear();
+  reportedPropositionIds.clear();
+  discoveredScopeMeta.clear();
   initAlloyQueue(config.alloyInstanceName);
   if (config.dataLayer) {
     initDatalayer(config.dataLayerInstanceName);
@@ -751,21 +841,15 @@ export async function martechEager() {
       applyPropositions(config.alloyInstanceName),
       config.personalizationTimeout,
     ).then((result) => {
-      onPageActivation(() => {
-        // Automatically report displayed propositions
-        sendAnalyticsEvent({
-          eventType: config.trackPageView
-            ? 'web.webpagedetails.pageViews'
-            : 'decisioning.propositionDisplay',
-          _experience: {
-            decisioning: {
-              propositions: response.propositions
-                .map((p) => ({ id: p.id, scope: p.scope, scopeDetails: p.scopeDetails })),
-              propositionEventType: { display: 1 },
-            },
-          },
+      // Page-view tracking is decoupled from proposition rendering. Proposition *display* events
+      // are emitted from applyPropositions as each proposition actually renders (see
+      // reportPropositionDisplay), so they aren't lost to the race between page activation and
+      // the async decoration ticks that apply offers. Here we only fire the plain page view.
+      if (config.trackPageView) {
+        onPageActivation(() => {
+          sendAnalyticsEvent({ eventType: 'web.webpagedetails.pageViews' });
         });
-      });
+      }
       return result;
     }).catch(() => {
       if (alloyConfig.debugEnabled) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -10,6 +10,8 @@ import {
   decorateTemplateAndTheme,
   waitForFirstImage,
   loadSection,
+  loadBlock,
+  readBlockConfig,
   sampleRUM,
   loadCSS,
   loadScript,
@@ -20,7 +22,7 @@ import {
 import {
   initMartech, martechEager, martechLazy, martechDelayed,
 } from '../plugins/martech/src/index.js';
-import { getAllMetadata, getLocale } from './shared.js';
+import { getAllMetadata, getLocale, isUE } from './shared.js';
 import { initPageSchemas } from './schema.js';
 import dynamicBlocks from '../blocks/dynamic/index.js';
 
@@ -189,6 +191,74 @@ async function loadTemplate(main, template) {
   }
 }
 
+// Structural EDS wrappers a Target offer can inject (e.g. a replaceHtml offer that brings in a
+// whole authored section). These are decorated by the section pipeline, not as blocks — calling
+// decorateBlock/loadBlock on them would try to load a non-existent block named after the wrapper.
+const isStructuralDiv = (el) => el.classList.contains('section')
+  || el.classList.contains('section-metadata')
+  || [...el.classList].some((c) => c.endsWith('-wrapper') || c.endsWith('-container'));
+
+function watchForTargetInjectedBlocks(main) {
+  const observer = new MutationObserver((mutations) => {
+    const toDecorate = new Set();
+
+    mutations.forEach(({ addedNodes }) => {
+      addedNodes.forEach((node) => {
+        if (node.nodeType !== Node.ELEMENT_NODE) return;
+        [node, ...node.querySelectorAll('div[class]')].forEach((el) => {
+          if (
+            el.tagName === 'DIV'
+            && el.classList.length > 0
+            && !el.classList.contains('block')
+            && !isStructuralDiv(el)
+            && !el.dataset.blockStatus
+            && !el.closest('.block')
+          ) {
+            toDecorate.add(el);
+          }
+        });
+      });
+    });
+
+    if (!toDecorate.size) return;
+
+    // Stay connected: Target/alloy apply offers across multiple mutation ticks, so disconnecting
+    // after the first batch would leave later-injected blocks undecorated. Already-decorated
+    // blocks are skipped above via the `block` class / `data-block-status` guards.
+
+    toDecorate.forEach((block) => {
+      const wrapper = block.parentElement;
+      const sectionMeta = wrapper?.querySelector('div.section-metadata');
+      if (sectionMeta) {
+        const section = block.closest('.section');
+        if (section) {
+          const meta = readBlockConfig(sectionMeta);
+          Object.keys(meta).forEach((key) => {
+            if (key === 'style') {
+              meta.style.split(',').map((s) => toClassName(s.trim())).filter(Boolean)
+                .forEach((s) => section.classList.add(s));
+            } else {
+              section.dataset[toCamelCase(key)] = meta[key];
+            }
+          });
+          sectionMeta.remove();
+        }
+      }
+    });
+
+    [...toDecorate].forEach((block) => {
+      decorateBlock(block);
+      decorateButtons(block);
+      decorateIcons(block);
+    });
+    Promise.all([...toDecorate].map((block) => loadBlock(block)))
+      .catch(() => { /* a failed block load shouldn't break the page */ });
+  });
+
+  observer.observe(main, { childList: true, subtree: true });
+}
+
+
 async function loadEager(doc) {
   getLocale();
   decorateTemplateAndTheme();
@@ -196,8 +266,9 @@ async function loadEager(doc) {
 
   // Consent stub — wire to real CMP later; true for demo
   const isConsentGiven = true;
+  const personalizationEnabled = !!getMetadata('target') && isConsentGiven;
 
-  const martechLoadedPromise = !IS_QUICK_EDIT && initMartech(
+  const martechLoadedPromise = !IS_EDITOR && initMartech(
     {
       datastreamId: 'd73be188-bc37-4ede-a5da-8aa7cd1e343b',
       orgId: '138A07885EE042D20A495CFA@AdobeOrg',
@@ -209,14 +280,12 @@ async function loadEager(doc) {
       },
     },
     {
-      personalization: !!getMetadata('target') && isConsentGiven,
+      personalization: personalizationEnabled,
       launchUrls: ['https://assets.adobedtm.com/ace20f3fb313/d4fa519d75cf/launch-452113bfea88.min.js'],
-      decisionScopes: ['homepage-hero-mbox', 'homepage-teaser-mbox'],
-      propositionMetadata: {
-        // Normal delivery: Form-Based html-content-item at homepage-hero-mbox
-        'homepage-hero-mbox': { selector: 'main .section:first-child', actionType: 'replaceHtml' },
-        'homepage-teaser-mbox': { selector: 'main .section:nth-child(2)', actionType: 'replaceHtml' },
-      },
+      // Decision scopes + selector mapping are auto-discovered from section-metadata
+      // `mbox` rows (server-rendered as `data-mbox` attributes), so no hardcoded
+      // config is needed here. See the plugins/martech README,
+      // "Working with Form-Based Activities".
     },
   );
 
@@ -228,6 +297,10 @@ async function loadEager(doc) {
       await runEager(document, { audiences: AUDIENCES }, getExperimentationContext());
     }
     decorateMain(main);
+    // Re-decorate EDS block markup that a Target offer injects after decoration has
+    // already run (e.g. a replaceHtml offer that brings in authored block HTML). Started
+    // before martechEager applies propositions so the observer is live when offers land.
+    if (personalizationEnabled && !IS_EDITOR) watchForTargetInjectedBlocks(main);
     document.body.classList.add('appear');
     await Promise.all([
       martechLoadedPromise && martechLoadedPromise.then(martechEager),
@@ -274,7 +347,7 @@ async function loadLazy(doc) {
   if (hash && element) element.scrollIntoView();
 
   loadFooter(footerEl);
-  if (!IS_QUICK_EDIT) await martechLazy();
+  if (!IS_EDITOR) await martechLazy();
 
   /* Scroll reveal: sections below the viewport animate in as they enter */
   if (main && 'IntersectionObserver' in window) {
@@ -356,9 +429,14 @@ async function loadLazy(doc) {
 const IS_QUICK_EDIT = new URL(window.location.href).searchParams.has('quick-edit');
 if (IS_QUICK_EDIT) import('../tools/quick-edit/quick-edit.js').then((mod) => mod.default());
 
+// Authoring surfaces (Sidekick quick-edit + Universal Editor). Martech (tracking +
+// personalization) is bypassed entirely here so offers never mutate the DOM while authoring
+// and the Target-injected-block observer can't fight UE/quick-edit DOM changes.
+const IS_EDITOR = IS_QUICK_EDIT || isUE();
+
 function loadDelayed() {
   window.setTimeout(() => {
-    if (!IS_QUICK_EDIT) martechDelayed();
+    if (!IS_EDITOR) martechDelayed();
     import('./delayed.js');
   }, 3000);
 }


### PR DESCRIPTION
Replace hardcoded mbox-to-selector config with author-controlled discovery driven by EDS section metadata, and harden the surrounding delivery path.

Plugin (vendored plugins/martech):
- Auto-discover decision scopes from `data-mbox` attributes (rendered from `mbox` section metadata); synthesize `.martech-mbox-<name>` selectors and request the scopes in the eager propositionFetch.
- Default actionType is setHtml (preserves the target element and its EDS decoration); replaceHtml/appendHtml are opt-in via `data-mbox-action`.
- Drop the propositionMetadata code-config and the non-visual VEC rescue subsystem; dom-action (VEC) offers flow straight to alloy. Form-Based (html-content-item) offers map to targets via the internal discovered-scope map only.
- Fix reporting: emit decisioning.propositionDisplay as offers render (idempotent per proposition id), decoupled from page activation; always request __view__ so VEC propositions aren't dropped.
- Validate discoveredScopeActionType, warn on sanitized-class collisions, and scope auto-discovery docs to the performance-optimized path.

Demo (scripts/scripts.js):
- Remove hardcoded decisionScopes/propositionMetadata from initMartech.
- Add watchForTargetInjectedBlocks to re-decorate raw EDS block markup that DA Send-to-Target offers inject after decoration has run.
- Bypass martech entirely in authoring surfaces via a single IS_EDITOR flag (quick-edit + Universal Editor) so offers never mutate the DOM while editing.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--demo--scdemos.aem.live/
- After: https://martech-iterate--demo--scdemos.aem.live/
