### PR TITLE
fix: hide library metadata from being seen when browsing block variants in the block libary

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -730,3 +730,8 @@ main > .section.warm {
   background-clip: text;
   color: transparent;
 }
+
+/* hide library metadata from being seen in block library */
+.library-metadata-wrapper {
+  display: none;
+}


### PR DESCRIPTION
Not polished to see the library-metadata show up in the preview of blocks variants when viewing it in the block library. The library metadata will still show in the (i) info icon on block library modal but not in the actual content which is how it is supposed to be.

Test URLs:
- Before: https://main--demo--scdemos.aem.page/docs/library/blocks/cards
- After: https://fix-lib-meta--demo--scdemos.aem.page/docs/library/blocks/cards
