### PR TITLE
fix(martech): sync vendored aem-martech plugin with PR #17 (Form-Based Target activities)

### DIFF
--- a/plugins/martech/README.md
+++ b/plugins/martech/README.md
@@ -1,6 +1,4 @@
-:construction: This is an early access technology and is still heavily in development. Reach out to us over Slack before using it.
-
-# AEM Edge Delivery Services Marketing Technology
+![aem-martech](./aem-martech.jpg)
 
 The AEM Marketing Technology plugin helps you quickly set up a complete MarTech stack for your AEM project. It is currently available to customers in collaboration with AEM Engineering via co-innovation VIP Projects. To implement your use cases, please reach out to the AEM Engineering team in the Slack channel dedicated to your project.
 
@@ -32,6 +30,7 @@ The AEM Marketing Technology plugin helps you quickly set up a complete MarTech 
   - [Consent Management](#consent-management)
       - [Integrating with AEM Consent Banner Block](#integrating-with-aem-consent-banner-block)
       - [Integrating with OneTrust](#integrating-with-onetrust)
+      - [Integrating with Cookiebot](#integrating-with-cookiebot)
   - [Working with Form-Based Activities](#working-with-form-based-activities)
   - [Working with Dynamic Content (SPAs)](#working-with-dynamic-content-spas)
   - [FAQ](#faq)
@@ -266,7 +265,7 @@ Initializes the library. This should be called once in `loadEager`.
 ---
 
 ### `updateUserConsent(consent)`
-Sets user consent based on the IAB TCF 2.0 standard.
+Sets user consent using the [Adobe standard v2.0](https://experienceleague.adobe.com/en/docs/experience-platform/landing/governance-privacy-security/consent/adobe/dataset) format. If you use a CMP based on IAB TCF 2.0, map its categories to the `collect`/`marketing`/`personalize`/`share` flags as shown in the [Consent Management](#consent-management) examples.
 
 - **`consent`** `{Object}`: An object detailing user consent choices (`collect`, `marketing`, `personalize`, `share`).
 
@@ -349,6 +348,30 @@ function consentEventHandler(ev) {
 window.addEventListener('consent.onetrust', consentEventHandler);
 ```
 
+#### Integrating with Cookiebot
+Example for [Cookiebot](https://www.cookiebot.com):
+```js
+function setupCookiebotConsent() {
+  function handleCookiebotConsent() {
+    const preferences = window.Cookiebot?.consent?.preferences || false;
+    const statistics = window.Cookiebot?.consent?.statistics || false;
+    const marketing = window.Cookiebot?.consent?.marketing || false;
+    
+    updateUserConsent({
+      collect: statistics,        // Statistics cookies
+      marketing: marketing,       // Marketing cookies
+      personalize: preferences,   // Preference cookies
+      share: marketing           // Marketing cookies
+    });
+  }
+
+  window.addEventListener('CookiebotOnConsentReady', handleCookiebotConsent);
+  window.addEventListener('CookiebotOnAccept', handleCookiebotConsent);
+}
+
+setupCookiebotConsent();
+```
+
 ## Working with Form-Based Activities
 
 Form-Based HTML offers in Adobe Target deliver an `html-content-item` proposition that
@@ -423,8 +446,8 @@ initMartech(webSDKConfig, {
 });
 ```
 
-See [`docs/form-based-target-activities.md`](https://github.com/adobe-rnd/aem-martech/blob/main/docs/form-based-target-activities.md)
-for a focused, author-facing walkthrough of using Form-Based activities.
+See [`docs/form-based-target-activities.md`](./docs/form-based-target-activities.md) for a
+focused, author-facing walkthrough of using Form-Based activities.
 
 ## Working with Dynamic Content (SPAs)
 
@@ -470,8 +493,15 @@ SDK initialization and configuration live in your project's code rather than the
 ## Dependencies
 
 This plugin includes the following core libraries:
-- **Adobe Experience Platform WebSDK**: `v2.28.0` (`alloy.min.js`)
-- **Adobe Client Data Layer**: `v2.0.2` (`acdl.min.js`)
+- **Adobe Experience Platform WebSDK**: `v2.31.1` (`alloy.min.js`)
+- **Adobe Client Data Layer**: `v3.0.1` (`acdl.min.js`)
+
+To update the vendored copies from Adobe's official distribution channels (the WebSDK
+self-hosting CDN and the ACDL npm package), and keep the version numbers above in sync, run:
+```sh
+npm run update:vendor               # latest published versions
+npm run update:vendor -- 2.31.1 3.0.1  # or specific versions
+```
 
 ## Web SDK Configuration
 

--- a/plugins/martech/package.json
+++ b/plugins/martech/package.json
@@ -3,11 +3,14 @@
   "version": "1.0.0",
   "main": "src/index.js",
   "scripts": {
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "update:vendor": "node ./scripts/update-vendor.mjs"
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/adobe/aem-martech.git"
+    "url": "git+ssh://git@github.com/adobe-rnd/aem-martech.git"
   },
   "author": "Adobe Inc.",
   "license": "Apache-2.0",
@@ -23,13 +26,15 @@
     "launch"
   ],
   "bugs": {
-    "url": "https://github.com/adobe/aem-martech/issues"
+    "url": "https://github.com/adobe-rnd/aem-martech/issues"
   },
-  "homepage": "https://github.com/adobe/aem-martech#readme",
+  "homepage": "https://github.com/adobe-rnd/aem-martech#readme",
   "devDependencies": {
     "@babel/eslint-parser": "7.22.15",
     "eslint": "8.48.0",
     "eslint-config-airbnb-base": "15.0.0",
-    "eslint-plugin-import": "2.28.1"
+    "eslint-plugin-import": "2.28.1",
+    "jsdom": "^29.0.0",
+    "vitest": "^4.0.0"
   }
 }

--- a/plugins/martech/src/index.js
+++ b/plugins/martech/src/index.js
@@ -160,10 +160,11 @@ function promiseWithTimeout(promise, timeout = 1000) {
   let timer;
   return Promise.race([
     promise,
-    new Promise((_, reject) => { timer = setTimeout(reject, timeout); }),
-  ]).finally((result) => {
+    new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`Operation timed out after ${timeout}ms`)), timeout);
+    }),
+  ]).finally(() => {
     clearTimeout(timer);
-    return result;
   });
 }
 
@@ -173,10 +174,26 @@ function promiseWithTimeout(promise, timeout = 1000) {
  * @throws a decorated error that can be intercepted by RUM handlers.
  */
 function handleRejectedPromise(error) {
-  const [, file, line] = error.stack.split('\n')[1].trim().split(' ')[1].match(/(.*):(\d+):(\d+)/);
-  error.sourceURL = file;
-  error.line = line;
+  try {
+    const [, file, line] = error.stack.split('\n')[1].trim().split(' ')[1].match(/(.*):(\d+):(\d+)/);
+    error.sourceURL = file;
+    error.line = line;
+  } catch (err) {
+    // Stack trace formats vary across browsers and the stack may not even be present,
+    // so never fail while just decorating the error
+  }
   throw error;
+}
+
+/**
+ * Ensures the library has been initialized, and throws an explicit error otherwise.
+ * @param {String} method The name of the public method being called
+ * @throws when the library was not initialized via `initMartech` yet
+ */
+function assertInitialized(method) {
+  if (!config) {
+    throw new Error(`Martech needs to be initialized before the \`${method}\` method is called`);
+  }
 }
 
 /**
@@ -192,12 +209,23 @@ function initAlloyQueue(instanceName) {
   }
   // eslint-disable-next-line no-underscore-dangle
   (window.__alloyNS ||= []).push(instanceName);
-  window[instanceName] = (...args) => new Promise((resolve, reject) => {
+  const stub = (...args) => new Promise((resolve, reject) => {
+    // Unlike the official base code, the push is deferred with a setTimeout: it breaks a
+    // spike of commands (typically the data preparation projects do before the LCP) into
+    // separate tasks so they do not pile up into one long blocking task during page load
     window.setTimeout(() => {
-      window[instanceName].q.push([resolve, reject, args]);
+      const instance = window[instanceName];
+      if (instance !== stub) {
+        // The real SDK replaced the stub (and drained its queue) while the push was
+        // pending, so forward the command to it directly or it would be lost
+        instance(...args).then(resolve, reject);
+      } else {
+        stub.q.push([resolve, reject, args]);
+      }
     });
   });
-  window[instanceName].q = [];
+  stub.q = [];
+  window[instanceName] = stub;
 }
 
 /**
@@ -208,9 +236,12 @@ function initAlloyQueue(instanceName) {
  * @param {String} instanceName The name of the instance in the blobal scope
  */
 function initDatalayer(instanceName) {
-  window[instanceName] ||= [];
+  // ACDL only ever processes the `adobeDataLayer` array, so always initialize it, and alias
+  // custom instance names to the same array so events pushed before the library is loaded
+  // are picked up when it initializes
+  window.adobeDataLayer ||= [];
   if (instanceName !== 'adobeDataLayer') {
-    window[instanceName] ||= [];
+    window[instanceName] ||= window.adobeDataLayer;
   }
 }
 
@@ -237,8 +268,7 @@ function getDefaultAlloyConfiguration() {
  * @returns {Promise<*>} a promise that the event was sent
  */
 export async function sendEvent(payload) {
-  // eslint-disable-next-line no-console
-  console.assert(config.alloyInstanceName && window[config.alloyInstanceName], 'Martech needs to be initialized before the `sendEvent` method is called');
+  assertInitialized('sendEvent');
   return window[config.alloyInstanceName]('sendEvent', payload);
 }
 
@@ -250,20 +280,23 @@ export async function sendEvent(payload) {
  * @returns {Promise<*>} a promise that the event was sent
  */
 export async function sendAnalyticsEvent(xdmData, dataMapping = {}, configOverrides = {}) {
-  // eslint-disable-next-line no-console
-  console.assert(config.alloyInstanceName && window[config.alloyInstanceName], 'Martech needs to be initialized before the `sendAnalyticsEvent` method is called');
+  assertInitialized('sendAnalyticsEvent');
   // eslint-disable-next-line no-console
   console.assert(config.analytics, 'Analytics tracking is disabled in the martech config');
+  if (!config.analytics) {
+    return Promise.resolve();
+  }
   try {
-    return sendEvent({
+    // Await here so rejections are actually caught by this block and decorated;
+    // returning the pending promise would bypass the catch entirely
+    return await sendEvent({
       documentUnloading: true,
       xdm: xdmData,
       data: dataMapping,
       edgeConfigOverrides: configOverrides,
     });
   } catch (err) {
-    handleRejectedPromise(new Error(err));
-    return Promise.reject(new Error(err));
+    return handleRejectedPromise(err instanceof Error ? err : new Error(err));
   }
 }
 
@@ -283,7 +316,7 @@ async function loadAndConfigureAlloy(instanceName, webSDKConfig) {
     pendingAlloyCommands.forEach((fn) => fn());
     pendingDatalayerEvents.forEach((args) => sendAnalyticsEvent(...args));
   } catch (err) {
-    handleRejectedPromise(new Error(err));
+    handleRejectedPromise(err instanceof Error ? err : new Error(err));
   }
 }
 
@@ -325,8 +358,10 @@ function onDecoratedElement(fn) {
  * @param {Object} payload the data to push
  */
 export function pushToDataLayer(payload) {
-  // eslint-disable-next-line no-console
-  console.assert(config.dataLayerInstanceName && window[config.dataLayerInstanceName], 'Martech needs to be initialized before the `pushToDataLayer` method is called');
+  assertInitialized('pushToDataLayer');
+  if (!config.dataLayer || !window[config.dataLayerInstanceName]) {
+    throw new Error('The data layer is disabled in the martech config');
+  }
   window[config.dataLayerInstanceName].push(payload);
 }
 
@@ -357,19 +392,21 @@ async function loadAndConfigureDataLayer() {
     }
     window[config.dataLayerInstanceName].push((dl) => {
       dl.addEventListener('adobeDataLayer:event', (payload) => {
-        const eventType = payload.event;
-        const args = [
-          { eventType, ...payload.xdm },
-          payload.data,
-          payload.configOverrides,
-        ];
-
         // Check whether the event should be processed or not
         if (!config.shouldProcessEvent(payload)) {
           return;
         }
 
-        delete payload.event;
+        // Do not mutate the payload: it is the data layer's own state object and other
+        // listeners may rely on it
+        const {
+          event: eventType, xdm, data, configOverrides,
+        } = payload;
+        const args = [
+          { eventType, ...xdm },
+          data,
+          configOverrides,
+        ];
 
         if (!isAlloyConfigured) {
           pendingDatalayerEvents.push(args);
@@ -387,7 +424,11 @@ async function loadAndConfigureDataLayer() {
       data = {};
     }
     if (!el.id) {
-      const index = [...document.querySelectorAll(`.${el.classList[0]}`)].indexOf(el);
+      const blockClass = el.classList[0];
+      const siblings = blockClass
+        ? [...document.querySelectorAll(`.${blockClass}`)]
+        : [...document.querySelectorAll('[data-block-data-layer]')].filter((e) => !e.classList.length);
+      const index = siblings.indexOf(el);
       el.id = `${data.parentId ? `${data.parentId}-` : ''}${index + 1}`;
     }
     window[config.dataLayerInstanceName].push({
@@ -401,21 +442,21 @@ async function loadAndConfigureDataLayer() {
  * Documentation:
  * https://experienceleague.adobe.com/en/docs/experience-platform/landing/governance-privacy-security/consent/adobe/dataset#structure
  * https://experienceleague.adobe.com/en/docs/experience-platform/xdm/data-types/consents
- * @param {Object} config The consent config to use
- * @param {Boolean} [config.collect] Whether data collection is allowed
- * @param {Boolean|Object} [config.marketing] Whether data can be used for marketing purposes
- * @param {String} [config.marketing.preferred] The preferred medium for marketing communication
- * @param {Boolean} [config.marketing.any] Whether any marketing channels are consented to or not
- * @param {Boolean} [config.marketing.email] Whether marketing emails are consented to or not
- * @param {Boolean} [config.marketing.push] Whether marketing push notifications are consented to
- * @param {Boolean} [config.marketing.sms] Whether marketing messages are consented to or not
- * @param {Boolean} [config.personalize] Whether data can be used for personalization purposes
- * @param {Boolean} [config.share] Whether data can be shared/sold to 3rd parties
- * @returns {Promise<*>} a promise that the consent setting shave been updated
+ * @param {Object} consent The consent config to use
+ * @param {Boolean} [consent.collect] Whether data collection is allowed
+ * @param {Boolean|Object} [consent.marketing] Whether data can be used for marketing purposes
+ * @param {String} [consent.marketing.preferred] The preferred medium for marketing communication
+ * @param {Boolean} [consent.marketing.email] Whether marketing emails are consented to or not
+ * @param {Boolean} [consent.marketing.push] Whether marketing push notifications are consented to
+ * @param {Boolean} [consent.marketing.sms] Whether marketing messages are consented to or not
+ * @param {Boolean} [consent.personalize] Whether data can be used for personalization purposes
+ * @param {Boolean} [consent.share] Whether data can be shared/sold to 3rd parties
+ * @returns {Promise<*>} a promise that the consent settings have been applied (if alloy is not
+ *                       configured yet, the promise only resolves once it is and the queued
+ *                       consent has effectively been set)
  */
 export async function updateUserConsent(consent) {
-  // eslint-disable-next-line no-console
-  console.assert(config.alloyInstanceName, 'Martech needs to be initialized before the `updateUserConsent` method is called');
+  assertInitialized('updateUserConsent');
 
   let marketingConfig;
   if (typeof consent.marketing === 'boolean') {
@@ -427,7 +468,9 @@ export async function updateUserConsent(consent) {
     marketingConfig = {
       preferred: consent.marketing.preferred || 'email',
       any: {
-        val: consent.marketing.email ? 'y' : 'n',
+        val: (consent.marketing.email || consent.marketing.push || consent.marketing.sms)
+          ? 'y'
+          : 'n',
       },
       email: {
         val: consent.marketing.email ? 'y' : 'n',
@@ -457,8 +500,9 @@ export async function updateUserConsent(consent) {
   if (isAlloyConfigured) {
     return fn();
   }
-  pendingAlloyCommands.push(fn);
-  return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    pendingAlloyCommands.push(() => fn().then(resolve, reject));
+  });
 }
 
 let response;
@@ -731,12 +775,15 @@ async function applyPropositions(instanceName) {
  * @returns a promise that the library was loaded and configured
  */
 export async function initMartech(webSDKConfig, martechConfig = {}) {
-  // eslint-disable-next-line no-console
-  console.assert(!config, 'Martech already initialized.');
-  // eslint-disable-next-line no-console
-  console.assert(webSDKConfig?.datastreamId || webSDKConfig?.edgeConfigId, 'Please set your "datastreamId" for the WebSDK config.');
-  // eslint-disable-next-line no-console
-  console.assert(webSDKConfig?.orgId, 'Please set your "orgId" for the WebSDK config.');
+  if (config) {
+    throw new Error('Martech is already initialized.');
+  }
+  if (!webSDKConfig?.datastreamId && !webSDKConfig?.edgeConfigId) {
+    throw new Error('Please set your "datastreamId" for the WebSDK config.');
+  }
+  if (!webSDKConfig?.orgId) {
+    throw new Error('Please set your "orgId" for the WebSDK config.');
+  }
 
   config = {
     ...DEFAULT_CONFIG,
@@ -758,12 +805,18 @@ export async function initMartech(webSDKConfig, martechConfig = {}) {
     ...getDefaultAlloyConfiguration(),
     ...webSDKConfig,
     onBeforeEventSend: (payload) => {
-      // ACDL is initialized in the lazy phase, so fetching from the JS array as a fallback during
-      // the eager phase
-      if (config.includeDataLayerState) {
-        const dlState = window.adobeDataLayer.getState
-          ? window.adobeDataLayer.getState()
-          : window.adobeDataLayer[0];
+      // ACDL is initialized in the lazy phase, so fall back to merging the queued plain
+      // objects during the eager phase
+      if (config.dataLayer && config.includeDataLayerState) {
+        const dl = window[config.dataLayerInstanceName];
+        let dlState;
+        if (dl?.getState) {
+          dlState = dl.getState();
+        } else if (Array.isArray(dl)) {
+          dlState = dl
+            .filter((entry) => typeof entry === 'object' && entry !== null && !entry.event)
+            .reduce((state, entry) => ({ ...state, ...entry }), {});
+        }
         payload.xdm = {
           ...payload.xdm,
           ...dlState,
@@ -827,7 +880,13 @@ export function initRumTracking(sampleRUM, options = {}) {
       cb(data);
     });
   } else {
-    track = (ev, cb) => document.addEventListener('rum', (data) => {
+    track = (ev, cb) => document.addEventListener('rum', (event) => {
+      // Filter for the requested checkpoint and unwrap the custom event detail, so both
+      // code paths pass the same payload shape to the callback
+      const data = event.detail || {};
+      if (data.checkpoint !== ev) {
+        return;
+      }
       debug('rum', ev, data);
       cb(data);
     });
@@ -840,7 +899,7 @@ export function initRumTracking(sampleRUM, options = {}) {
  * @returns a `true` if personalization is enabled, or `false` otherwise
  */
 export function isPersonalizationEnabled() {
-  return config.personalization;
+  return !!config?.personalization;
 }
 
 /**
@@ -850,8 +909,10 @@ export function isPersonalizationEnabled() {
  * `applyPersonalization`.
  */
 export async function getPersonalizationForView(viewName) {
-  // eslint-disable-next-line no-console
-  console.assert(viewName, 'The `viewName` parameter needs to be defined');
+  assertInitialized('getPersonalizationForView');
+  if (!viewName) {
+    throw new Error('The `viewName` parameter needs to be defined');
+  }
   return sendEvent({
     renderDecisions: true,
     xdm: {
@@ -868,8 +929,10 @@ export async function getPersonalizationForView(viewName) {
  * @returns a promise that the propositions were applied
  */
 export async function applyPersonalization(viewName) {
-  // eslint-disable-next-line no-console
-  console.assert(viewName, 'The `viewName` parameter needs to be defined');
+  assertInitialized('applyPersonalization');
+  if (!viewName) {
+    throw new Error('The `viewName` parameter needs to be defined');
+  }
   return window[config.alloyInstanceName]('applyPropositions', { viewName });
 }
 
@@ -878,9 +941,8 @@ export async function applyPersonalization(viewName) {
  * @returns a promise that the eager logic was executed
  */
 export async function martechEager() {
+  assertInitialized('martechEager');
   if (config.personalization && config.performanceOptimized) {
-    // eslint-disable-next-line no-console
-    console.assert(config.alloyInstanceName && window[config.alloyInstanceName], 'Martech needs to be initialized before the `martechEager` method is called');
     return promiseWithTimeout(
       applyPropositions(config.alloyInstanceName),
       config.personalizationTimeout,
@@ -935,25 +997,42 @@ export async function martechEager() {
  * @returns a promise that the lazy logic was executed
  */
 export async function martechLazy() {
+  assertInitialized('martechLazy');
   if (config.dataLayer) {
-    await loadAndConfigureDataLayer({});
+    await loadAndConfigureDataLayer();
   }
 
-  if (!config.personalization && config.performanceOptimized) {
-    await loadAndConfigureAlloy(config.alloyInstanceName, alloyConfig);
+  if (!config.personalization) {
+    // Alloy is only loaded in the eager phase when personalization is enabled,
+    // so make sure it is loaded here in all other configurations
+    if (!isAlloyConfigured) {
+      await loadAndConfigureAlloy(config.alloyInstanceName, alloyConfig);
+    }
     if (config.trackPageView) {
       onPageActivation(() => {
         sendAnalyticsEvent({ eventType: 'web.webpagedetails.pageViews' });
       });
     }
   } else if (!config.performanceOptimized) {
-    const renderDecisionResponse = await sendEvent({
-      renderDecisions: true,
-      decisionScopes: [...new Set(['__view__', ...(config.decisionScopes || [])])],
-    });
-    response = renderDecisionResponse;
-    document.body.style.visibility = null;
-    // Automatically report displayed propositions
+    try {
+      const renderDecisionResponse = await promiseWithTimeout(
+        sendEvent({
+          renderDecisions: true,
+          decisionScopes: [...new Set(['__view__', ...(config.decisionScopes || [])])],
+        }),
+        config.personalizationTimeout,
+      );
+      response = renderDecisionResponse;
+    } catch (err) {
+      if (alloyConfig.debugEnabled) {
+        // eslint-disable-next-line no-console
+        console.warn('Could not apply personalization in time. Either backend is taking too long, or user did not give consent in time.');
+      }
+    } finally {
+      // Always restore the page visibility, even if the personalization request failed
+      // (network error, request blocked by an ad blocker, consent not given in time, …)
+      document.body.style.visibility = null;
+    }
     if (config.trackPageView) {
       onPageActivation(() => {
         sendAnalyticsEvent({ eventType: 'web.webpagedetails.pageViews' });
@@ -967,10 +1046,19 @@ export async function martechLazy() {
  * @returns a promise that the delayed logic was executed
  */
 export async function martechDelayed() {
-  // eslint-disable-next-line no-console
-  console.assert(config.alloyInstanceName && window[config.alloyInstanceName], 'Martech needs to be initialized before the `martechDelayed` method is called');
+  assertInitialized('martechDelayed');
 
   const { launchUrls } = config;
-  return Promise.all(launchUrls.map((url) => import(url)))
-    .catch((err) => handleRejectedPromise(new Error(err)));
+  // Load the containers as classic scripts rather than via a dynamic import: ES modules
+  // execute in strict mode, which can break Launch custom-code actions and extensions
+  // relying on sloppy-mode semantics (implicit globals, `this` being the window, …)
+  return Promise.all(launchUrls.map((url) => new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = url;
+    script.async = true;
+    script.onload = resolve;
+    script.onerror = () => reject(new Error(`Could not load launch container: ${url}`));
+    document.head.appendChild(script);
+  })))
+    .catch((err) => handleRejectedPromise(err instanceof Error ? err : new Error(err)));
 }

--- a/plugins/martech/src/index.js
+++ b/plugins/martech/src/index.js
@@ -699,15 +699,11 @@ async function applyPropositions(instanceName) {
       }).filter(Boolean),
     }))
     .filter((p) => p.items.length > 0);
-  // The extended schema filter (dom-action + html-content-item) feeds the display-accuracy set:
-  // only propositions handed to alloy for DOM application count as displayed once rendered.
   domActionPropositionIds = new Set(propositions.map((p) => p.id));
   let disconnect;
   let isApplying = false;
   let pendingRun = false;
   const run = async () => {
-    // Re-scan for `data-mbox` scopes decorated after the eager fetch, and warn on any that arrive
-    // too late to be personalized this load.
     const lateScopes = discoverPropositionScopes(document);
     lateScopes.forEach((scope) => {
       if (!response?.propositions?.some((p) => p.scope === scope)) {
@@ -726,8 +722,6 @@ async function applyPropositions(instanceName) {
     }
     isApplying = true;
     try {
-      // Form-Based html-content-item offers carry no selector; hand alloy the resolved
-      // selector/actionType per scope via the metadata map.
       const applyOptions = { propositions };
       if (Object.keys(htmlContentMetadata).length) {
         applyOptions.metadata = htmlContentMetadata;

--- a/plugins/martech/src/index.js
+++ b/plugins/martech/src/index.js
@@ -290,6 +290,7 @@ async function loadAndConfigureAlloy(instanceName, webSDKConfig) {
 /**
  * Runs the specified function on every decorated block/section
  * @param {Function} fn The function to call
+ * @returns {Function} a function to stop watching for new decorated blocks/sections
  */
 function onDecoratedElement(fn) {
   // Apply propositions to all already decorated blocks/sections
@@ -304,16 +305,19 @@ function onDecoratedElement(fn) {
       fn();
     }
   });
-  // Watch sections and blocks being decorated async
-  observer.observe(document.querySelector('main'), {
-    subtree: true,
-    attributes: true,
-    attributeFilter: ['data-block-status', 'data-section-status'],
-  });
+  // Watch sections and blocks being decorated async (pages without a `main`, like error
+  // pages, are still watched via the body observer below)
+  const main = document.querySelector('main');
+  if (main) {
+    observer.observe(main, {
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-block-status', 'data-section-status'],
+    });
+  }
   // Watch anything else added to the body
-  document.querySelectorAll('body').forEach((el) => {
-    observer.observe(el, { childList: true });
-  });
+  observer.observe(document.body, { childList: true });
+  return () => observer.disconnect();
 }
 
 /**
@@ -458,6 +462,12 @@ export async function updateUserConsent(consent) {
 }
 
 let response;
+// Tracks which fetched propositions are handed to alloy for DOM application (dom-action or
+// html-content-item), which of those were effectively rendered, and which were already reported
+// as displayed. renderedPropositionIds/reportedPropositionIds are declared at module top.
+let domActionPropositionIds = new Set();
+let initialDisplayReported = false;
+let personalizationTimedOut = false;
 
 /**
  * Resolves the target selector and actionType for a Form-Based html-content-item.
@@ -544,34 +554,42 @@ function discoverPropositionScopes(root) {
 }
 
 /**
- * Fires a single `decisioning.propositionDisplay` event covering one or more propositions
- * alloy has rendered, so Target Activity reporting records an impression. Idempotent per
- * proposition id for the life of the page.
+ * Reports the specified propositions as displayed to the backend.
+ * @param {Object[]} propositions the propositions that were displayed
+ * @returns a promise that the display event was sent
  */
-function reportPropositionDisplay(instanceName, propositions) {
-  // Idempotent: each proposition is reported at most once for the life of the page, so this is
-  // safe to call per decoration tick (and from deferred page-activation callbacks).
-  const toReport = (propositions || []).filter((p) => p && !reportedPropositionIds.has(p.id));
-  if (!toReport.length) return;
-  toReport.forEach((p) => {
-    renderedPropositionIds.add(p.id);
-    reportedPropositionIds.add(p.id);
-  });
-  window[instanceName]('sendEvent', {
-    xdm: {
-      eventType: 'decisioning.propositionDisplay',
-      _experience: {
-        decisioning: {
-          propositions: toReport.map((p) => ({
-            id: p.id,
-            scope: p.scope,
-            scopeDetails: p.scopeDetails,
-          })),
-          propositionEventType: { display: 1 },
-        },
+function reportDisplayedPropositions(propositions) {
+  return sendAnalyticsEvent({
+    eventType: 'decisioning.propositionDisplay',
+    _experience: {
+      decisioning: {
+        propositions,
+        propositionEventType: { display: 1 },
       },
     },
-  }).catch(() => { /* reporting failure shouldn't break the page */ });
+  });
+}
+
+/**
+ * Reports propositions that were rendered after the initial display report was already sent
+ * (i.e. on blocks that were decorated late), so their displays are not lost.
+ * @param {String[]} propositionIds the ids of the newly rendered propositions
+ */
+function reportLateDisplayedPropositions(propositionIds) {
+  if (!initialDisplayReported) {
+    // The initial report has not been sent yet, and will include those propositions
+    return;
+  }
+  const newlyDisplayed = (response?.propositions || [])
+    .filter((p) => propositionIds.includes(p.id) && !reportedPropositionIds.has(p.id))
+    .map((p) => ({ id: p.id, scope: p.scope, scopeDetails: p.scopeDetails }));
+  if (!newlyDisplayed.length) {
+    return;
+  }
+  newlyDisplayed.forEach((p) => reportedPropositionIds.add(p.id));
+  onPageActivation(() => {
+    reportDisplayedPropositions(newlyDisplayed);
+  });
 }
 
 /**
@@ -608,6 +626,11 @@ async function applyPropositions(instanceName) {
   if (!renderDecisionResponse?.propositions) {
     return [];
   }
+  if (personalizationTimedOut) {
+    // The response came back after the personalization timeout: the page is already showing
+    // the default content, so do not apply the propositions anymore to avoid flickering
+    return renderDecisionResponse;
+  }
   // dom-action (VEC) items carry their own selector and are applied by alloy directly, exactly
   // as upstream does. html-content-item (Form-Based) offers don't carry a selector, so resolve a
   // target from the offer or from `data-mbox` auto-discovery and hand it to alloy via the metadata
@@ -632,47 +655,65 @@ async function applyPropositions(instanceName) {
       }).filter(Boolean),
     }))
     .filter((p) => p.items.length > 0);
-  onDecoratedElement(async () => {
+  // The extended schema filter (dom-action + html-content-item) feeds the display-accuracy set:
+  // only propositions handed to alloy for DOM application count as displayed once rendered.
+  domActionPropositionIds = new Set(propositions.map((p) => p.id));
+  let disconnect;
+  let isApplying = false;
+  let pendingRun = false;
+  const run = async () => {
+    // Re-scan for `data-mbox` scopes decorated after the eager fetch, and warn on any that arrive
+    // too late to be personalized this load.
     const lateScopes = discoverPropositionScopes(document);
     lateScopes.forEach((scope) => {
       if (!response?.propositions?.some((p) => p.scope === scope)) {
         debug('martech', `mbox "${scope}" discovered after eager propositionFetch; not personalized this load`);
       }
     });
-    if (!propositions.length) {
+    if (!propositions.length || personalizationTimedOut) {
+      disconnect?.();
       return;
     }
-    const applyOptions = { propositions };
-    if (Object.keys(htmlContentMetadata).length) {
-      applyOptions.metadata = htmlContentMetadata;
+    // Serialize the applications, so concurrent DOM updates do not apply the same
+    // propositions twice; a trailing run picks up whatever was decorated in the meantime
+    if (isApplying) {
+      pendingRun = true;
+      return;
     }
-    const appliedPropositions = await window[instanceName](
-      'applyPropositions',
-      applyOptions,
-    );
-    // Single guarded pass over the applied items: drop rendered propositions from the retry set
-    // and collect the freshly-rendered ones to report. Reporting display *here* (as alloy
-    // actually renders, across decoration ticks) rather than at page-activation avoids the race
-    // where activation fires before async decoration has applied anything.
-    const renderedNow = [];
-    appliedPropositions.propositions?.forEach((appliedItem) => {
-      if (!appliedItem.renderAttempted) return;
-      propositions = propositions.filter((p) => p.id !== appliedItem.id);
-      if (!renderedPropositionIds.has(appliedItem.id)) {
-        const original = response?.propositions?.find((p) => p.id === appliedItem.id);
-        renderedNow.push({
-          id: appliedItem.id,
-          scope: appliedItem.scope ?? original?.scope,
-          scopeDetails: appliedItem.scopeDetails ?? original?.scopeDetails,
-        });
+    isApplying = true;
+    try {
+      // Form-Based html-content-item offers carry no selector; hand alloy the resolved
+      // selector/actionType per scope via the metadata map.
+      const applyOptions = { propositions };
+      if (Object.keys(htmlContentMetadata).length) {
+        applyOptions.metadata = htmlContentMetadata;
       }
-      renderedPropositionIds.add(appliedItem.id);
-    });
-    // Prerender-aware: defer the display impression until the page is actually activated.
-    if (renderedNow.length) {
-      onPageActivation(() => reportPropositionDisplay(instanceName, renderedNow));
+      const appliedPropositions = await window[instanceName](
+        'applyPropositions',
+        applyOptions,
+      );
+      const newlyRendered = [];
+      appliedPropositions.propositions?.forEach((item) => {
+        if (item.renderAttempted) {
+          renderedPropositionIds.add(item.id);
+          newlyRendered.push(item.id);
+          propositions = propositions.filter((p) => p.id !== item.id);
+        }
+      });
+      reportLateDisplayedPropositions(newlyRendered);
+      if (!propositions.length) {
+        // Everything was applied, no need to keep watching the DOM
+        disconnect?.();
+      }
+    } finally {
+      isApplying = false;
+      if (pendingRun) {
+        pendingRun = false;
+        run();
+      }
     }
-  });
+  };
+  disconnect = onDecoratedElement(run);
   return renderDecisionResponse;
 }
 
@@ -705,6 +746,9 @@ export async function initMartech(webSDKConfig, martechConfig = {}) {
   renderedPropositionIds.clear();
   reportedPropositionIds.clear();
   discoveredScopeMeta.clear();
+  domActionPropositionIds = new Set();
+  initialDisplayReported = false;
+  personalizationTimedOut = false;
   initAlloyQueue(config.alloyInstanceName);
   if (config.dataLayer) {
     initDatalayer(config.dataLayerInstanceName);
@@ -840,22 +884,44 @@ export async function martechEager() {
     return promiseWithTimeout(
       applyPropositions(config.alloyInstanceName),
       config.personalizationTimeout,
-    ).then((result) => {
-      // Page-view tracking is decoupled from proposition rendering. Proposition *display* events
-      // are emitted from applyPropositions as each proposition actually renders (see
-      // reportPropositionDisplay), so they aren't lost to the race between page activation and
-      // the async decoration ticks that apply offers. Here we only fire the plain page view.
-      if (config.trackPageView) {
-        onPageActivation(() => {
-          sendAnalyticsEvent({ eventType: 'web.webpagedetails.pageViews' });
-        });
-      }
-      return result;
-    }).catch(() => {
+    ).catch(() => {
+      // Stop applying propositions that arrive after the timeout: the default content is
+      // already showing and applying them late would flicker the page
+      personalizationTimedOut = true;
       if (alloyConfig.debugEnabled) {
         // eslint-disable-next-line no-console
         console.warn('Could not apply personalization in time. Either backend is taking too long, or user did not give consent in time.');
       }
+    }).finally(() => {
+      // Track the page view (and report displayed propositions) even if the personalization
+      // fetch timed out or returned no propositions, so analytics are not lost
+      onPageActivation(() => {
+        // Only report propositions that were effectively rendered, or that are not
+        // dom-actions (and are handled by project code instead)
+        const propositions = (response?.propositions || [])
+          .filter((p) => !domActionPropositionIds.has(p.id) || renderedPropositionIds.has(p.id))
+          .map((p) => ({ id: p.id, scope: p.scope, scopeDetails: p.scopeDetails }));
+        propositions.forEach((p) => reportedPropositionIds.add(p.id));
+        initialDisplayReported = true;
+        if (!config.trackPageView && !propositions.length) {
+          // Without propositions there is nothing to report, and the page view itself
+          // is tracked elsewhere
+          return;
+        }
+        sendAnalyticsEvent({
+          eventType: config.trackPageView
+            ? 'web.webpagedetails.pageViews'
+            : 'decisioning.propositionDisplay',
+          ...(propositions.length && {
+            _experience: {
+              decisioning: {
+                propositions,
+                propositionEventType: { display: 1 },
+              },
+            },
+          }),
+        });
+      });
     });
   }
   if (config.personalization) {


### PR DESCRIPTION
## Summary

Updates the vendored `aem-martech` plugin (`plugins/martech/`) to match
[adobe-rnd/aem-martech#17](https://github.com/adobe-rnd/aem-martech/pull/17), which adds
**Form-Based (`html-content-item`) Adobe Target activity** support. That PR has since been squashed
and merged with upstream `main`, so this sync also brings main's hardening
([#21](https://github.com/adobe-rnd/aem-martech/pull/21) phase resilience,
[#24](https://github.com/adobe-rnd/aem-martech/pull/24)–[#31](https://github.com/adobe-rnd/aem-martech/pull/31) fixes,
[#27](https://github.com/adobe-rnd/aem-martech/pull/27) real-error-handling,
[#28](https://github.com/adobe-rnd/aem-martech/pull/28) proposition-application + display accuracy).

This lets the demo showcase author-controlled Target personalization via `data-mbox` section
metadata — authors tag a section with an `mbox` row and the plugin auto-discovers it; no code
change is needed to add or move a Target location.

## What changed

Re-vendored the runtime files that differed from the plugin's PR head:

- **`plugins/martech/src/index.js`** — Form-Based `html-content-item` support (resolve a selector
  from the offer or from `data-mbox`, hand it to alloy via the metadata map), non-visual selector
  guard, `data-mbox` auto-discovery, and always-request `__view__` — layered onto main's hardened
  `applyPropositions` ([#28](https://github.com/adobe-rnd/aem-martech/pull/28)), phase resilience
  ([#21](https://github.com/adobe-rnd/aem-martech/pull/21)), and real-error-handling
  ([#27](https://github.com/adobe-rnd/aem-martech/pull/27)).
- **`plugins/martech/README.md`** — Form-Based usage docs + merged main docs.
- **`plugins/martech/package.json`** — `adobe-rnd` repo-url fix + test-infra metadata.

The demo vendors only the plugin's **runtime subset**; aem-martech's dev tooling (`test/`,
`vitest.config.js`, CI) is intentionally not vendored.

## Test URLs

- **Before:** https://main--demo--scdemos.aem.live/drafts/sagar/aemug-martech-demo
- **After:** https://martech-iterate--demo--scdemos.aem.live/drafts/sagar/aemug-martech-demo

## Validation

Verified locally (`aem up`) against real Adobe Target Form-Based activities on the test page:

- `data-mbox` auto-discovery of two scopes on one page;
- a `replaceHtml` offer (target element and its `data-mbox` removed and replaced) and a `setHtml`
  offer (target element preserved, only its content swapped), each applied to the correct element,
  **exactly once**, with the `MutationObserver` disconnecting afterward;
- page view + proposition display reported; a non-applicable proposition dropped by the
  schema/selector filter;
- no console errors originating from the plugin.

Upstream plugin (aem-martech#17): `npm test` → **71/71 vitest tests pass**; `npm run lint` clean.
